### PR TITLE
add cookie-banner

### DIFF
--- a/app/configurations/config.hb.js
+++ b/app/configurations/config.hb.js
@@ -377,7 +377,7 @@ export default configMerger(walttiConfig, {
           },
           {
             type: 'a',
-            content: 'Datenshutz',
+            content: 'Datenschutz',
             href: 'https://www.herrenberg.de/datenschutz',
           },
         ],

--- a/app/configurations/config.hb.js
+++ b/app/configurations/config.hb.js
@@ -349,7 +349,41 @@ export default configMerger(walttiConfig, {
         url: '/assets/geojson/hb-layers/charging.geojson',
       },
     ],
-},
-staticMessagesUrl: STATIC_MESSAGE_URL,
+  },
+
+  staticMessages: [
+    {
+      id: '2',
+      priority: -1,
+      shouldTrigger: true,
+      content: {
+        en: [
+          {
+            type: 'text',
+            content:
+              'We use cookies to improve our services. By using this site, you agree to its use of cookies. Read more: ',
+          },
+          {
+            type: 'a',
+            content: 'Privacy Statement',
+            href: 'https://www.herrenberg.de/datenschutz',
+          },
+        ],
+        de: [
+          {
+            type: 'text',
+            content:
+              'Diese Seite benutzt Cookies. Wenn Sie die Seite weiterhin benutzten stimmen Sie dem zu. Mehr Informationen: ',
+          },
+          {
+            type: 'a',
+            content: 'Datenshutz',
+            href: 'https://www.herrenberg.de/datenschutz',
+          },
+        ],
+      },
+    },
+  ],
+  staticMessagesUrl: STATIC_MESSAGE_URL,
 
 });


### PR DESCRIPTION
Since Matomo is used, we should inform users about tracking, cookie usage. #61 

Banner is added. Link goes to https://www.herrenberg.de/datenschutz .