### PR TITLE
fix bus icons

### DIFF
--- a/app/component/map/ItineraryLine.js
+++ b/app/component/map/ItineraryLine.js
@@ -165,6 +165,7 @@ class ItineraryLine extends React.Component {
                 }}
                 mode={mode.toLowerCase()}
                 renderText={leg.transitLeg && this.props.showTransferLabels}
+                endPoint
               />,
             );
             objs.push(
@@ -180,6 +181,7 @@ class ItineraryLine extends React.Component {
                 }}
                 mode={mode.toLowerCase()}
                 renderText={leg.transitLeg && this.props.showTransferLabels}
+                endPoint
               />,
             );
           }

--- a/app/component/map/non-tile-layer/StopMarker.js
+++ b/app/component/map/non-tile-layer/StopMarker.js
@@ -34,12 +34,14 @@ class StopMarker extends React.Component {
     renderName: PropTypes.bool,
     disableModeIcons: PropTypes.bool,
     selected: PropTypes.bool,
+    endPoint: PropTypes.bool,
   };
 
   static defaultProps = {
     renderName: false,
     disableModeIcons: false,
     selected: false,
+    endPoint: false,
   };
 
   static contextTypes = {
@@ -101,6 +103,29 @@ class StopMarker extends React.Component {
 
     if (radius === 0) {
       iconSvg = '';
+    }
+
+    if (this.props.mode === 'bus' && this.props.endPoint) {
+      const icon = Icon.asString({
+        img: 'icon_map-bus',
+        className: 'mode-icon',
+      });
+      let size;
+      if (zoom <= this.context.config.stopsSmallMaxZoom) {
+        size = this.context.config.stopsIconSize.small;
+      } else if (this.props.selected) {
+        size = this.context.config.stopsIconSize.selected;
+      } else {
+        size = this.context.config.stopsIconSize.default;
+      }
+      return L.divIcon({
+        html: icon,
+        iconSize: [size + 3, size + 3],
+        className: cx('cursor-pointer', this.props.mode, {
+          small: size === this.context.config.stopsIconSize.small,
+          selected: this.props.selected,
+        }),
+      });
     }
 
     return L.divIcon({


### PR DESCRIPTION
## Proposed Changes
  - show bus icons on trip endpoints
  - only show bus icon when transit mode is bus

BUS trip:
![image](https://user-images.githubusercontent.com/54352878/82543678-3c554200-9b54-11ea-95c5-2717e393650c.png)

not BUS trips:
![image](https://user-images.githubusercontent.com/54352878/82543768-5bec6a80-9b54-11ea-8c1b-dfd53254d466.png)

![image](https://user-images.githubusercontent.com/54352878/82543782-5f7ff180-9b54-11ea-9ebf-1984e01a2db4.png)

closes #211  

