### PR TITLE
Fix geojson layer routing

### DIFF
--- a/app/component/map/PointFeatureMarker.js
+++ b/app/component/map/PointFeatureMarker.js
@@ -120,7 +120,12 @@ const PointFeatureMarker = ({ feature, icons, language }) => {
     'popupContent',
     language,
   );
-  const address = getPropertyValueOrDefault(properties, 'address', language);
+  const address = getPropertyValueOrDefault(
+    properties,
+    'address',
+    language,
+    header,
+  );
 
   if (properties.name === 'Fahrradreparaturstation') {
     popupContent =

--- a/app/component/map/PointFeatureMarker.js
+++ b/app/component/map/PointFeatureMarker.js
@@ -115,10 +115,15 @@ const PointFeatureMarker = ({ feature, icons, language }) => {
 
   const { icon } = properties;
   const header = getPropertyValueOrDefault(properties, 'name', language);
-  let address = getPropertyValueOrDefault(properties, 'address', language);
+  let popupContent = getPropertyValueOrDefault(
+    properties,
+    'popupContent',
+    language,
+  );
+  const address = getPropertyValueOrDefault(properties, 'address', language);
 
   if (properties.name === 'Fahrradreparaturstation') {
-    address =
+    popupContent =
       language === 'de'
         ? 'Derzeit nicht in Betrieb – voraussichtlich Anfang / Mitte Juni mit verbessertem Angebot wieder verfügbar – ggf. mit leicht geändertem Standort.'
         : 'Currently out of order. The service will resume in June, possibly at a slightly different location.';
@@ -154,6 +159,7 @@ const PointFeatureMarker = ({ feature, icons, language }) => {
             name={useDescriptionAsHeader ? description : header}
             unlinked
           />
+          {popupContent && <div className="card-text">{popupContent}</div>}
         </div>
       </Card>
       <MarkerPopupBottom

--- a/app/component/map/PointFeatureMarker.js
+++ b/app/component/map/PointFeatureMarker.js
@@ -120,6 +120,7 @@ const PointFeatureMarker = ({ feature, icons, language }) => {
     'popupContent',
     language,
   );
+  // Use header as default, so address wont be undefined.
   const address = getPropertyValueOrDefault(
     properties,
     'address',
@@ -135,7 +136,15 @@ const PointFeatureMarker = ({ feature, icons, language }) => {
   }
 
   const city = getPropertyValueOrDefault(properties, 'city', language);
-  const description = city ? `${address}, ${city}` : address;
+  let description = null;
+  // Only display address field as description if it is a real address + add city if exists.
+  if (address !== header && city) {
+    description = `${address}, ${city}`;
+  } else if (address !== header) {
+    description = address;
+  } else if (city) {
+    description = city;
+  }
   const useDescriptionAsHeader = !header;
 
   const hasCustomIcon = icon && icon.id && icons[icon.id];

--- a/sass/base/_elements.scss
+++ b/sass/base/_elements.scss
@@ -9,6 +9,13 @@ $border-radius-rounded: 30px;
   line-height: $line-height-normal;
   overflow-x: hidden;
 }
+
+.card-text {
+  font-size: 1.2em;
+  font-family: $font-family;
+  margin: 3px 0;
+}
+
 .card-header {
   background-color: $white;
   padding: 0.4em 0 0.5em;

--- a/static/assets/geojson/hb-layers/bicycle-parking.geojson
+++ b/static/assets/geojson/hb-layers/bicycle-parking.geojson
@@ -7,12 +7,12 @@
         "name": "Fahrradparkplatz Bahnhof Herrenberg",
         "name_en": "Fahrradparkplatz Bahnhof Herrenberg",
         "name_de": "Fahrradparkplatz Bahnhof Herrenberg",
-        "address": "Stellpl\u00e4tze: 132",
-        "address_de": "Stellpl\u00e4tze: 132",
-        "address_en": "Capacity: 132",
+        "popupContent": "Stellpl\u00e4tze: 132",
+        "popupContent_de": "Stellpl\u00e4tze: 132",
+        "popupContent_en": "Capacity: 132",
         "icon": {
           "id": "bikeParkCovIcon",
-          "svg": "<svg xmlns=\"http://www.w3.org/2000/svg\" id=\"Ebene_1\" data-name=\"Ebene 1\" viewBox=\"0 0 32.53 32.53\">\n  <defs>\n    <style>\n      .cls-2{fill:#fff}\n    </style>\n  </defs>\n  <path fill=\"#005ab4\" d=\"M320.34 384.05a16.27 16.27 0 11-16.26-16.27 16.27 16.27 0 0116.26 16.27\" transform=\"translate(-287.81 -367.78)\"/>\n  <path d=\"M298.37 373v.32a.6.6 0 00.83.56l4.65-1.9a.61.61 0 01.46 0l4.64 1.9a.61.61 0 00.84-.56V373a.6.6 0 00-.38-.56l-5.1-2.09a.61.61 0 00-.46 0l-5.11 2.09a.6.6 0 00-.37.56\" class=\"cls-2\" transform=\"translate(-287.81 -367.78)\"/>\n  <path d=\"M307.13 376.2a2.34 2.34 0 00-2.51-2.37h-2.95v7.6h1.49v-2.86h1.46a2.34 2.34 0 002.51-2.37m-1.49 0a1 1 0 01-1.1 1h-1.38v-2.09h1.38a1 1 0 011.1 1.05M306.71 384.17a1.47 1.47 0 01-1-.44 1.38 1.38 0 01-.46-1 1.43 1.43 0 01.46-1.05 1.41 1.41 0 011-.46 1.38 1.38 0 011 .46 1.49 1.49 0 01.44 1.05 1.5 1.5 0 01-1.48 1.48zm-7.87 4.88a3.57 3.57 0 012.65 1.09 3.66 3.66 0 011.08 2.67 3.67 3.67 0 01-3.73 3.73 3.69 3.69 0 01-2.67-1.07 3.57 3.57 0 01-1.09-2.66 3.63 3.63 0 011.09-2.67 3.67 3.67 0 012.67-1.09zm0 6.36a2.56 2.56 0 002.6-2.6 2.59 2.59 0 00-.75-1.86 2.51 2.51 0 00-1.85-.77 2.63 2.63 0 00-2.63 2.63 2.48 2.48 0 00.77 1.85 2.57 2.57 0 001.86.75zm4.32-7.48l1.65 1.72v4.64h-1.47v-3.73l-2.43-2.1a1.19 1.19 0 01-.42-1.06 1.42 1.42 0 01.42-1l2.11-2.11a1.19 1.19 0 011.06-.42 1.86 1.86 0 011.19.42l1.44 1.44a3.64 3.64 0 002.67 1.12v1.52a5.15 5.15 0 01-3.79-1.59l-.6-.59zm6.15 1.12a3.72 3.72 0 013.76 3.76 3.57 3.57 0 01-1.09 2.66 3.66 3.66 0 01-2.67 1.07 3.66 3.66 0 01-3.72-3.73 3.69 3.69 0 011.07-2.67 3.59 3.59 0 012.65-1.09zm0 6.36a2.56 2.56 0 001.86-.75 2.49 2.49 0 00.78-1.85 2.65 2.65 0 00-2.64-2.63 2.49 2.49 0 00-1.84.77 2.56 2.56 0 00-.76 1.86 2.58 2.58 0 002.6 2.6z\" class=\"cls-2\" transform=\"translate(-287.81 -367.78)\"/>\n</svg>"
+          "svg": "<svg xmlns=\"http://www.w3.org/2000/svg\" id=\"Ebene_1\" data-name=\"Ebene 1\" viewBox=\"0 0 32.53 32.53\">  <defs>    <style>      .cls-2{fill:#fff}    </style>  </defs>  <path fill=\"#005ab4\" d=\"M320.34 384.05a16.27 16.27 0 11-16.26-16.27 16.27 16.27 0 0116.26 16.27\" transform=\"translate(-287.81 -367.78)\"/>  <path d=\"M298.37 373v.32a.6.6 0 00.83.56l4.65-1.9a.61.61 0 01.46 0l4.64 1.9a.61.61 0 00.84-.56V373a.6.6 0 00-.38-.56l-5.1-2.09a.61.61 0 00-.46 0l-5.11 2.09a.6.6 0 00-.37.56\" class=\"cls-2\" transform=\"translate(-287.81 -367.78)\"/>  <path d=\"M307.13 376.2a2.34 2.34 0 00-2.51-2.37h-2.95v7.6h1.49v-2.86h1.46a2.34 2.34 0 002.51-2.37m-1.49 0a1 1 0 01-1.1 1h-1.38v-2.09h1.38a1 1 0 011.1 1.05M306.71 384.17a1.47 1.47 0 01-1-.44 1.38 1.38 0 01-.46-1 1.43 1.43 0 01.46-1.05 1.41 1.41 0 011-.46 1.38 1.38 0 011 .46 1.49 1.49 0 01.44 1.05 1.5 1.5 0 01-1.48 1.48zm-7.87 4.88a3.57 3.57 0 012.65 1.09 3.66 3.66 0 011.08 2.67 3.67 3.67 0 01-3.73 3.73 3.69 3.69 0 01-2.67-1.07 3.57 3.57 0 01-1.09-2.66 3.63 3.63 0 011.09-2.67 3.67 3.67 0 012.67-1.09zm0 6.36a2.56 2.56 0 002.6-2.6 2.59 2.59 0 00-.75-1.86 2.51 2.51 0 00-1.85-.77 2.63 2.63 0 00-2.63 2.63 2.48 2.48 0 00.77 1.85 2.57 2.57 0 001.86.75zm4.32-7.48l1.65 1.72v4.64h-1.47v-3.73l-2.43-2.1a1.19 1.19 0 01-.42-1.06 1.42 1.42 0 01.42-1l2.11-2.11a1.19 1.19 0 011.06-.42 1.86 1.86 0 011.19.42l1.44 1.44a3.64 3.64 0 002.67 1.12v1.52a5.15 5.15 0 01-3.79-1.59l-.6-.59zm6.15 1.12a3.72 3.72 0 013.76 3.76 3.57 3.57 0 01-1.09 2.66 3.66 3.66 0 01-2.67 1.07 3.66 3.66 0 01-3.72-3.73 3.69 3.69 0 011.07-2.67 3.59 3.59 0 012.65-1.09zm0 6.36a2.56 2.56 0 001.86-.75 2.49 2.49 0 00.78-1.85 2.65 2.65 0 00-2.64-2.63 2.49 2.49 0 00-1.84.77 2.56 2.56 0 00-.76 1.86 2.58 2.58 0 002.6 2.6z\" class=\"cls-2\" transform=\"translate(-287.81 -367.78)\"/></svg>"
         }
       },
       "geometry": {
@@ -29,9 +29,9 @@
         "name_en": "Covered bike park",
         "name_de": "\u00dcberdachter Fahrradstellplatz",
         "name": "\u00dcberdachter Fahrradstellplatz",
-        "address": "",
-        "address_de": "",
-        "address_en": "",
+        "popupContent": "",
+        "popupContent_de": "",
+        "popupContent_en": "",
         "icon": {
           "id": "bikeParkCovIcon"
         }
@@ -50,9 +50,9 @@
         "name_en": "Covered bike park",
         "name_de": "\u00dcberdachter Fahrradstellplatz",
         "name": "\u00dcberdachter Fahrradstellplatz",
-        "address": "",
-        "address_de": "",
-        "address_en": "",
+        "popupContent": "",
+        "popupContent_de": "",
+        "popupContent_en": "",
         "icon": {
           "id": "bikeParkCovIcon"
         }
@@ -71,9 +71,9 @@
         "name_en": "Covered bike park",
         "name_de": "\u00dcberdachter Fahrradstellplatz",
         "name": "\u00dcberdachter Fahrradstellplatz",
-        "address": "",
-        "address_de": "",
-        "address_en": "",
+        "popupContent": "",
+        "popupContent_de": "",
+        "popupContent_en": "",
         "icon": {
           "id": "bikeParkCovIcon"
         }
@@ -92,9 +92,9 @@
         "name_en": "Covered bike park",
         "name_de": "\u00dcberdachter Fahrradstellplatz",
         "name": "\u00dcberdachter Fahrradstellplatz",
-        "address": "Stellpl\u00e4tze: 40, Geb\u00fchrenpflichtig:: nein",
-        "address_de": "Stellpl\u00e4tze: 40, Geb\u00fchrenpflichtig:: nein",
-        "address_en": "Capacity: 40, Fee: no",
+        "popupContent": "Stellpl\u00e4tze: 40, Geb\u00fchrenpflichtig: nein",
+        "popupContent_de": "Stellpl\u00e4tze: 40, Geb\u00fchrenpflichtig: nein",
+        "popupContent_en": "Capacity: 40, Fee: no",
         "icon": {
           "id": "bikeParkCovIcon"
         }
@@ -113,9 +113,9 @@
         "name_en": "Covered bike park",
         "name_de": "\u00dcberdachter Fahrradstellplatz",
         "name": "\u00dcberdachter Fahrradstellplatz",
-        "address": "Stellpl\u00e4tze: 40, Geb\u00fchrenpflichtig:: nein",
-        "address_de": "Stellpl\u00e4tze: 40, Geb\u00fchrenpflichtig:: nein",
-        "address_en": "Capacity: 40, Fee: no",
+        "popupContent": "Stellpl\u00e4tze: 40, Geb\u00fchrenpflichtig: nein",
+        "popupContent_de": "Stellpl\u00e4tze: 40, Geb\u00fchrenpflichtig: nein",
+        "popupContent_en": "Capacity: 40, Fee: no",
         "icon": {
           "id": "bikeParkCovIcon"
         }
@@ -134,9 +134,9 @@
         "name_en": "Covered bike park",
         "name_de": "\u00dcberdachter Fahrradstellplatz",
         "name": "\u00dcberdachter Fahrradstellplatz",
-        "address": "Stellpl\u00e4tze: 50, Geb\u00fchrenpflichtig:: nein",
-        "address_de": "Stellpl\u00e4tze: 50, Geb\u00fchrenpflichtig:: nein",
-        "address_en": "Capacity: 50, Fee: no",
+        "popupContent": "Stellpl\u00e4tze: 50, Geb\u00fchrenpflichtig: nein",
+        "popupContent_de": "Stellpl\u00e4tze: 50, Geb\u00fchrenpflichtig: nein",
+        "popupContent_en": "Capacity: 50, Fee: no",
         "icon": {
           "id": "bikeParkCovIcon"
         }
@@ -155,9 +155,9 @@
         "name_en": "Covered bike park",
         "name_de": "\u00dcberdachter Fahrradstellplatz",
         "name": "\u00dcberdachter Fahrradstellplatz",
-        "address": "Stellpl\u00e4tze: 196, Geb\u00fchrenpflichtig:: nein",
-        "address_de": "Stellpl\u00e4tze: 196, Geb\u00fchrenpflichtig:: nein",
-        "address_en": "Capacity: 196, Fee: no",
+        "popupContent": "Stellpl\u00e4tze: 196, Geb\u00fchrenpflichtig: nein",
+        "popupContent_de": "Stellpl\u00e4tze: 196, Geb\u00fchrenpflichtig: nein",
+        "popupContent_en": "Capacity: 196, Fee: no",
         "icon": {
           "id": "bikeParkCovIcon"
         }
@@ -176,9 +176,9 @@
         "name_en": "Covered bike park",
         "name_de": "\u00dcberdachter Fahrradstellplatz",
         "name": "\u00dcberdachter Fahrradstellplatz",
-        "address": "Stellpl\u00e4tze: 50",
-        "address_de": "Stellpl\u00e4tze: 50",
-        "address_en": "Capacity: 50",
+        "popupContent": "Stellpl\u00e4tze: 50",
+        "popupContent_de": "Stellpl\u00e4tze: 50",
+        "popupContent_en": "Capacity: 50",
         "icon": {
           "id": "bikeParkCovIcon"
         }
@@ -197,9 +197,9 @@
         "name_en": "Covered bike park",
         "name_de": "\u00dcberdachter Fahrradstellplatz",
         "name": "\u00dcberdachter Fahrradstellplatz",
-        "address": "Stellpl\u00e4tze: 14",
-        "address_de": "Stellpl\u00e4tze: 14",
-        "address_en": "Capacity: 14",
+        "popupContent": "Stellpl\u00e4tze: 14",
+        "popupContent_de": "Stellpl\u00e4tze: 14",
+        "popupContent_en": "Capacity: 14",
         "icon": {
           "id": "bikeParkCovIcon"
         }
@@ -218,9 +218,9 @@
         "name_en": "Covered bike park",
         "name_de": "\u00dcberdachter Fahrradstellplatz",
         "name": "\u00dcberdachter Fahrradstellplatz",
-        "address": "Stellpl\u00e4tze: 40",
-        "address_de": "Stellpl\u00e4tze: 40",
-        "address_en": "Capacity: 40",
+        "popupContent": "Stellpl\u00e4tze: 40",
+        "popupContent_de": "Stellpl\u00e4tze: 40",
+        "popupContent_en": "Capacity: 40",
         "icon": {
           "id": "bikeParkCovIcon"
         }
@@ -239,9 +239,9 @@
         "name_en": "Covered bike park",
         "name_de": "\u00dcberdachter Fahrradstellplatz",
         "name": "\u00dcberdachter Fahrradstellplatz",
-        "address": "",
-        "address_de": "",
-        "address_en": "",
+        "popupContent": "Stellpl\u00e4tze: 24",
+        "popupContent_de": "Stellpl\u00e4tze: 24",
+        "popupContent_en": "Capacity: 24",
         "icon": {
           "id": "bikeParkCovIcon"
         }
@@ -260,9 +260,9 @@
         "name_en": "Covered bike park",
         "name_de": "\u00dcberdachter Fahrradstellplatz",
         "name": "\u00dcberdachter Fahrradstellplatz",
-        "address": "Stellpl\u00e4tze: 100",
-        "address_de": "Stellpl\u00e4tze: 100",
-        "address_en": "Capacity: 100",
+        "popupContent": "Stellpl\u00e4tze: 100",
+        "popupContent_de": "Stellpl\u00e4tze: 100",
+        "popupContent_en": "Capacity: 100",
         "icon": {
           "id": "bikeParkCovIcon"
         }
@@ -281,9 +281,9 @@
         "name_en": "Covered bike park",
         "name_de": "\u00dcberdachter Fahrradstellplatz",
         "name": "\u00dcberdachter Fahrradstellplatz",
-        "address": "Stellpl\u00e4tze: 100",
-        "address_de": "Stellpl\u00e4tze: 100",
-        "address_en": "Capacity: 100",
+        "popupContent": "Stellpl\u00e4tze: 100",
+        "popupContent_de": "Stellpl\u00e4tze: 100",
+        "popupContent_en": "Capacity: 100",
         "icon": {
           "id": "bikeParkCovIcon"
         }
@@ -302,9 +302,9 @@
         "name_en": "Covered bike park",
         "name_de": "\u00dcberdachter Fahrradstellplatz",
         "name": "\u00dcberdachter Fahrradstellplatz",
-        "address": "Stellpl\u00e4tze: 60",
-        "address_de": "Stellpl\u00e4tze: 60",
-        "address_en": "Capacity: 60",
+        "popupContent": "Stellpl\u00e4tze: 60",
+        "popupContent_de": "Stellpl\u00e4tze: 60",
+        "popupContent_en": "Capacity: 60",
         "icon": {
           "id": "bikeParkCovIcon"
         }
@@ -323,9 +323,9 @@
         "name_en": "Covered bike park",
         "name_de": "\u00dcberdachter Fahrradstellplatz",
         "name": "\u00dcberdachter Fahrradstellplatz",
-        "address": "Stellpl\u00e4tze: 30",
-        "address_de": "Stellpl\u00e4tze: 30",
-        "address_en": "Capacity: 30",
+        "popupContent": "Stellpl\u00e4tze: 30",
+        "popupContent_de": "Stellpl\u00e4tze: 30",
+        "popupContent_en": "Capacity: 30",
         "icon": {
           "id": "bikeParkCovIcon"
         }
@@ -333,8 +333,8 @@
       "geometry": {
         "type": "Point",
         "coordinates": [
-          8.9089414,
-          48.5618172
+          8.9089419,
+          48.5618222
         ]
       }
     },
@@ -344,9 +344,9 @@
         "name_en": "Covered bike park",
         "name_de": "\u00dcberdachter Fahrradstellplatz",
         "name": "\u00dcberdachter Fahrradstellplatz",
-        "address": "",
-        "address_de": "",
-        "address_en": "",
+        "popupContent": "",
+        "popupContent_de": "",
+        "popupContent_en": "",
         "icon": {
           "id": "bikeParkCovIcon"
         }
@@ -365,9 +365,9 @@
         "name_en": "Covered bike park",
         "name_de": "\u00dcberdachter Fahrradstellplatz",
         "name": "\u00dcberdachter Fahrradstellplatz",
-        "address": "Stellpl\u00e4tze: 30, Geb\u00fchrenpflichtig:: nein",
-        "address_de": "Stellpl\u00e4tze: 30, Geb\u00fchrenpflichtig:: nein",
-        "address_en": "Capacity: 30, Fee: no",
+        "popupContent": "Stellpl\u00e4tze: 30, Geb\u00fchrenpflichtig: nein",
+        "popupContent_de": "Stellpl\u00e4tze: 30, Geb\u00fchrenpflichtig: nein",
+        "popupContent_en": "Capacity: 30, Fee: no",
         "icon": {
           "id": "bikeParkCovIcon"
         }
@@ -386,9 +386,9 @@
         "name_en": "Covered bike park",
         "name_de": "\u00dcberdachter Fahrradstellplatz",
         "name": "\u00dcberdachter Fahrradstellplatz",
-        "address": "",
-        "address_de": "",
-        "address_en": "",
+        "popupContent": "",
+        "popupContent_de": "",
+        "popupContent_en": "",
         "icon": {
           "id": "bikeParkCovIcon"
         }
@@ -407,9 +407,9 @@
         "name_en": "Covered bike park",
         "name_de": "\u00dcberdachter Fahrradstellplatz",
         "name": "\u00dcberdachter Fahrradstellplatz",
-        "address": "",
-        "address_de": "",
-        "address_en": "",
+        "popupContent": "",
+        "popupContent_de": "",
+        "popupContent_en": "",
         "icon": {
           "id": "bikeParkCovIcon"
         }
@@ -428,9 +428,9 @@
         "name_en": "Covered bike park",
         "name_de": "\u00dcberdachter Fahrradstellplatz",
         "name": "\u00dcberdachter Fahrradstellplatz",
-        "address": "",
-        "address_de": "",
-        "address_en": "",
+        "popupContent": "",
+        "popupContent_de": "",
+        "popupContent_en": "",
         "icon": {
           "id": "bikeParkCovIcon"
         }
@@ -449,9 +449,9 @@
         "name_en": "Covered bike park",
         "name_de": "\u00dcberdachter Fahrradstellplatz",
         "name": "\u00dcberdachter Fahrradstellplatz",
-        "address": "Stellpl\u00e4tze: 10",
-        "address_de": "Stellpl\u00e4tze: 10",
-        "address_en": "Capacity: 10",
+        "popupContent": "Stellpl\u00e4tze: 10",
+        "popupContent_de": "Stellpl\u00e4tze: 10",
+        "popupContent_en": "Capacity: 10",
         "icon": {
           "id": "bikeParkCovIcon"
         }
@@ -470,9 +470,9 @@
         "name_en": "Covered bike park",
         "name_de": "\u00dcberdachter Fahrradstellplatz",
         "name": "\u00dcberdachter Fahrradstellplatz",
-        "address": "Stellpl\u00e4tze: 32",
-        "address_de": "Stellpl\u00e4tze: 32",
-        "address_en": "Capacity: 32",
+        "popupContent": "Stellpl\u00e4tze: 32",
+        "popupContent_de": "Stellpl\u00e4tze: 32",
+        "popupContent_en": "Capacity: 32",
         "icon": {
           "id": "bikeParkCovIcon"
         }
@@ -491,9 +491,9 @@
         "name_en": "Covered bike park",
         "name_de": "\u00dcberdachter Fahrradstellplatz",
         "name": "\u00dcberdachter Fahrradstellplatz",
-        "address": "",
-        "address_de": "",
-        "address_en": "",
+        "popupContent": "",
+        "popupContent_de": "",
+        "popupContent_en": "",
         "icon": {
           "id": "bikeParkCovIcon"
         }
@@ -512,9 +512,9 @@
         "name_en": "Covered bike park",
         "name_de": "\u00dcberdachter Fahrradstellplatz",
         "name": "\u00dcberdachter Fahrradstellplatz",
-        "address": "Geb\u00fchrenpflichtig:: nein",
-        "address_de": "Geb\u00fchrenpflichtig:: nein",
-        "address_en": "Fee: no",
+        "popupContent": "Stellpl\u00e4tze: 36, Geb\u00fchrenpflichtig: nein",
+        "popupContent_de": "Stellpl\u00e4tze: 36, Geb\u00fchrenpflichtig: nein",
+        "popupContent_en": "Capacity: 36, Fee: no",
         "icon": {
           "id": "bikeParkCovIcon"
         }
@@ -522,8 +522,8 @@
       "geometry": {
         "type": "Point",
         "coordinates": [
-          8.9429489,
-          48.6616624
+          8.8680318,
+          48.5850229
         ]
       }
     },
@@ -533,9 +533,93 @@
         "name_en": "Covered bike park",
         "name_de": "\u00dcberdachter Fahrradstellplatz",
         "name": "\u00dcberdachter Fahrradstellplatz",
-        "address": "Stellpl\u00e4tze: 24",
-        "address_de": "Stellpl\u00e4tze: 24",
-        "address_en": "Capacity: 24",
+        "popupContent": "Stellpl\u00e4tze: 54, Geb\u00fchrenpflichtig: nein",
+        "popupContent_de": "Stellpl\u00e4tze: 54, Geb\u00fchrenpflichtig: nein",
+        "popupContent_en": "Capacity: 54, Fee: no",
+        "icon": {
+          "id": "bikeParkCovIcon"
+        }
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          8.9429158,
+          48.6616755
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "name_en": "Covered bike park",
+        "name_de": "\u00dcberdachter Fahrradstellplatz",
+        "name": "\u00dcberdachter Fahrradstellplatz",
+        "popupContent": "Stellpl\u00e4tze: 48",
+        "popupContent_de": "Stellpl\u00e4tze: 48",
+        "popupContent_en": "Capacity: 48",
+        "icon": {
+          "id": "bikeParkCovIcon"
+        }
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          8.9452658,
+          48.6627925
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "name_en": "Covered bike park",
+        "name_de": "\u00dcberdachter Fahrradstellplatz",
+        "name": "\u00dcberdachter Fahrradstellplatz",
+        "popupContent": "Stellpl\u00e4tze: 21",
+        "popupContent_de": "Stellpl\u00e4tze: 21",
+        "popupContent_en": "Capacity: 21",
+        "icon": {
+          "id": "bikeParkCovIcon"
+        }
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          8.942657,
+          48.6623814
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "name_en": "Covered bike park",
+        "name_de": "\u00dcberdachter Fahrradstellplatz",
+        "name": "\u00dcberdachter Fahrradstellplatz",
+        "popupContent": "Stellpl\u00e4tze: 8",
+        "popupContent_de": "Stellpl\u00e4tze: 8",
+        "popupContent_en": "Capacity: 8",
+        "icon": {
+          "id": "bikeParkCovIcon"
+        }
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          8.9426941,
+          48.6623062
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "name_en": "Covered bike park",
+        "name_de": "\u00dcberdachter Fahrradstellplatz",
+        "name": "\u00dcberdachter Fahrradstellplatz",
+        "popupContent": "Stellpl\u00e4tze: 24",
+        "popupContent_de": "Stellpl\u00e4tze: 24",
+        "popupContent_en": "Capacity: 24",
         "icon": {
           "id": "bikeParkCovIcon"
         }
@@ -554,9 +638,9 @@
         "name_en": "Covered bike park",
         "name_de": "\u00dcberdachter Fahrradstellplatz",
         "name": "\u00dcberdachter Fahrradstellplatz",
-        "address": "Stellpl\u00e4tze: 30",
-        "address_de": "Stellpl\u00e4tze: 30",
-        "address_en": "Capacity: 30",
+        "popupContent": "Stellpl\u00e4tze: 30",
+        "popupContent_de": "Stellpl\u00e4tze: 30",
+        "popupContent_en": "Capacity: 30",
         "icon": {
           "id": "bikeParkCovIcon"
         }
@@ -575,9 +659,9 @@
         "name_en": "Covered bike park",
         "name_de": "\u00dcberdachter Fahrradstellplatz",
         "name": "\u00dcberdachter Fahrradstellplatz",
-        "address": "Stellpl\u00e4tze: 24",
-        "address_de": "Stellpl\u00e4tze: 24",
-        "address_en": "Capacity: 24",
+        "popupContent": "Stellpl\u00e4tze: 24",
+        "popupContent_de": "Stellpl\u00e4tze: 24",
+        "popupContent_en": "Capacity: 24",
         "icon": {
           "id": "bikeParkCovIcon"
         }
@@ -596,9 +680,9 @@
         "name_en": "Covered bike park",
         "name_de": "\u00dcberdachter Fahrradstellplatz",
         "name": "\u00dcberdachter Fahrradstellplatz",
-        "address": "Stellpl\u00e4tze: 16",
-        "address_de": "Stellpl\u00e4tze: 16",
-        "address_en": "Capacity: 16",
+        "popupContent": "Stellpl\u00e4tze: 16",
+        "popupContent_de": "Stellpl\u00e4tze: 16",
+        "popupContent_en": "Capacity: 16",
         "icon": {
           "id": "bikeParkCovIcon"
         }
@@ -617,9 +701,9 @@
         "name_en": "Covered bike park",
         "name_de": "\u00dcberdachter Fahrradstellplatz",
         "name": "\u00dcberdachter Fahrradstellplatz",
-        "address": "Stellpl\u00e4tze: 10, Geb\u00fchrenpflichtig:: nein",
-        "address_de": "Stellpl\u00e4tze: 10, Geb\u00fchrenpflichtig:: nein",
-        "address_en": "Capacity: 10, Fee: no",
+        "popupContent": "Stellpl\u00e4tze: 10, Geb\u00fchrenpflichtig: nein",
+        "popupContent_de": "Stellpl\u00e4tze: 10, Geb\u00fchrenpflichtig: nein",
+        "popupContent_en": "Capacity: 10, Fee: no",
         "icon": {
           "id": "bikeParkCovIcon"
         }
@@ -638,9 +722,9 @@
         "name_en": "Covered bike park",
         "name_de": "\u00dcberdachter Fahrradstellplatz",
         "name": "\u00dcberdachter Fahrradstellplatz",
-        "address": "Stellpl\u00e4tze: 6",
-        "address_de": "Stellpl\u00e4tze: 6",
-        "address_en": "Capacity: 6",
+        "popupContent": "Stellpl\u00e4tze: 6",
+        "popupContent_de": "Stellpl\u00e4tze: 6",
+        "popupContent_en": "Capacity: 6",
         "icon": {
           "id": "bikeParkCovIcon"
         }
@@ -659,9 +743,9 @@
         "name_en": "Covered bike park",
         "name_de": "\u00dcberdachter Fahrradstellplatz",
         "name": "\u00dcberdachter Fahrradstellplatz",
-        "address": "Stellpl\u00e4tze: 16, Geb\u00fchrenpflichtig:: nein",
-        "address_de": "Stellpl\u00e4tze: 16, Geb\u00fchrenpflichtig:: nein",
-        "address_en": "Capacity: 16, Fee: no",
+        "popupContent": "Stellpl\u00e4tze: 16, Geb\u00fchrenpflichtig: nein",
+        "popupContent_de": "Stellpl\u00e4tze: 16, Geb\u00fchrenpflichtig: nein",
+        "popupContent_en": "Capacity: 16, Fee: no",
         "icon": {
           "id": "bikeParkCovIcon"
         }
@@ -680,9 +764,9 @@
         "name_en": "Covered bike park",
         "name_de": "\u00dcberdachter Fahrradstellplatz",
         "name": "\u00dcberdachter Fahrradstellplatz",
-        "address": "Stellpl\u00e4tze: 14, Geb\u00fchrenpflichtig:: nein",
-        "address_de": "Stellpl\u00e4tze: 14, Geb\u00fchrenpflichtig:: nein",
-        "address_en": "Capacity: 14, Fee: no",
+        "popupContent": "Stellpl\u00e4tze: 14, Geb\u00fchrenpflichtig: nein",
+        "popupContent_de": "Stellpl\u00e4tze: 14, Geb\u00fchrenpflichtig: nein",
+        "popupContent_en": "Capacity: 14, Fee: no",
         "icon": {
           "id": "bikeParkCovIcon"
         }
@@ -701,9 +785,9 @@
         "name_en": "Covered bike park",
         "name_de": "\u00dcberdachter Fahrradstellplatz",
         "name": "\u00dcberdachter Fahrradstellplatz",
-        "address": "Stellpl\u00e4tze: 130",
-        "address_de": "Stellpl\u00e4tze: 130",
-        "address_en": "Capacity: 130",
+        "popupContent": "Stellpl\u00e4tze: 130",
+        "popupContent_de": "Stellpl\u00e4tze: 130",
+        "popupContent_en": "Capacity: 130",
         "icon": {
           "id": "bikeParkCovIcon"
         }
@@ -722,9 +806,9 @@
         "name_en": "Covered bike park",
         "name_de": "\u00dcberdachter Fahrradstellplatz",
         "name": "\u00dcberdachter Fahrradstellplatz",
-        "address": "Stellpl\u00e4tze: 16",
-        "address_de": "Stellpl\u00e4tze: 16",
-        "address_en": "Capacity: 16",
+        "popupContent": "Stellpl\u00e4tze: 16",
+        "popupContent_de": "Stellpl\u00e4tze: 16",
+        "popupContent_en": "Capacity: 16",
         "icon": {
           "id": "bikeParkCovIcon"
         }
@@ -743,9 +827,9 @@
         "name_en": "Covered bike park",
         "name_de": "\u00dcberdachter Fahrradstellplatz",
         "name": "\u00dcberdachter Fahrradstellplatz",
-        "address": "Stellpl\u00e4tze: 16",
-        "address_de": "Stellpl\u00e4tze: 16",
-        "address_en": "Capacity: 16",
+        "popupContent": "Stellpl\u00e4tze: 16",
+        "popupContent_de": "Stellpl\u00e4tze: 16",
+        "popupContent_en": "Capacity: 16",
         "icon": {
           "id": "bikeParkCovIcon"
         }
@@ -764,9 +848,9 @@
         "name_en": "Covered bike park",
         "name_de": "\u00dcberdachter Fahrradstellplatz",
         "name": "\u00dcberdachter Fahrradstellplatz",
-        "address": "Stellpl\u00e4tze: 8",
-        "address_de": "Stellpl\u00e4tze: 8",
-        "address_en": "Capacity: 8",
+        "popupContent": "Stellpl\u00e4tze: 8",
+        "popupContent_de": "Stellpl\u00e4tze: 8",
+        "popupContent_en": "Capacity: 8",
         "icon": {
           "id": "bikeParkCovIcon"
         }
@@ -785,9 +869,9 @@
         "name_en": "Covered bike park",
         "name_de": "\u00dcberdachter Fahrradstellplatz",
         "name": "\u00dcberdachter Fahrradstellplatz",
-        "address": "Stellpl\u00e4tze: 44",
-        "address_de": "Stellpl\u00e4tze: 44",
-        "address_en": "Capacity: 44",
+        "popupContent": "Stellpl\u00e4tze: 44",
+        "popupContent_de": "Stellpl\u00e4tze: 44",
+        "popupContent_en": "Capacity: 44",
         "icon": {
           "id": "bikeParkCovIcon"
         }
@@ -795,7 +879,7 @@
       "geometry": {
         "type": "Point",
         "coordinates": [
-          9.0039432,
+          9.0040183,
           48.6881945
         ]
       }
@@ -806,9 +890,9 @@
         "name_en": "Covered bike park",
         "name_de": "\u00dcberdachter Fahrradstellplatz",
         "name": "\u00dcberdachter Fahrradstellplatz",
-        "address": "Stellpl\u00e4tze: 12",
-        "address_de": "Stellpl\u00e4tze: 12",
-        "address_en": "Capacity: 12",
+        "popupContent": "Stellpl\u00e4tze: 12",
+        "popupContent_de": "Stellpl\u00e4tze: 12",
+        "popupContent_en": "Capacity: 12",
         "icon": {
           "id": "bikeParkCovIcon"
         }
@@ -816,8 +900,8 @@
       "geometry": {
         "type": "Point",
         "coordinates": [
-          9.0043816,
-          48.6884627
+          9.0044078,
+          48.6884437
         ]
       }
     },
@@ -827,9 +911,9 @@
         "name_en": "Covered bike park",
         "name_de": "\u00dcberdachter Fahrradstellplatz",
         "name": "\u00dcberdachter Fahrradstellplatz",
-        "address": "Stellpl\u00e4tze: 6",
-        "address_de": "Stellpl\u00e4tze: 6",
-        "address_en": "Capacity: 6",
+        "popupContent": "Stellpl\u00e4tze: 6",
+        "popupContent_de": "Stellpl\u00e4tze: 6",
+        "popupContent_en": "Capacity: 6",
         "icon": {
           "id": "bikeParkCovIcon"
         }
@@ -848,9 +932,9 @@
         "name_en": "Covered bike park",
         "name_de": "\u00dcberdachter Fahrradstellplatz",
         "name": "\u00dcberdachter Fahrradstellplatz",
-        "address": "Stellpl\u00e4tze: 50",
-        "address_de": "Stellpl\u00e4tze: 50",
-        "address_en": "Capacity: 50",
+        "popupContent": "Stellpl\u00e4tze: 50",
+        "popupContent_de": "Stellpl\u00e4tze: 50",
+        "popupContent_en": "Capacity: 50",
         "icon": {
           "id": "bikeParkCovIcon"
         }
@@ -869,9 +953,9 @@
         "name_en": "Covered bike park",
         "name_de": "\u00dcberdachter Fahrradstellplatz",
         "name": "\u00dcberdachter Fahrradstellplatz",
-        "address": "Stellpl\u00e4tze: 6",
-        "address_de": "Stellpl\u00e4tze: 6",
-        "address_en": "Capacity: 6",
+        "popupContent": "Stellpl\u00e4tze: 6",
+        "popupContent_de": "Stellpl\u00e4tze: 6",
+        "popupContent_en": "Capacity: 6",
         "icon": {
           "id": "bikeParkCovIcon"
         }
@@ -890,9 +974,9 @@
         "name_en": "Covered bike park",
         "name_de": "\u00dcberdachter Fahrradstellplatz",
         "name": "\u00dcberdachter Fahrradstellplatz",
-        "address": "",
-        "address_de": "",
-        "address_en": "",
+        "popupContent": "",
+        "popupContent_de": "",
+        "popupContent_en": "",
         "icon": {
           "id": "bikeParkCovIcon"
         }
@@ -911,9 +995,9 @@
         "name_en": "Covered bike park",
         "name_de": "\u00dcberdachter Fahrradstellplatz",
         "name": "\u00dcberdachter Fahrradstellplatz",
-        "address": "Stellpl\u00e4tze: 40",
-        "address_de": "Stellpl\u00e4tze: 40",
-        "address_en": "Capacity: 40",
+        "popupContent": "Stellpl\u00e4tze: 40",
+        "popupContent_de": "Stellpl\u00e4tze: 40",
+        "popupContent_en": "Capacity: 40",
         "icon": {
           "id": "bikeParkCovIcon"
         }
@@ -932,9 +1016,9 @@
         "name_en": "Covered bike park",
         "name_de": "\u00dcberdachter Fahrradstellplatz",
         "name": "\u00dcberdachter Fahrradstellplatz",
-        "address": "Stellpl\u00e4tze: 12",
-        "address_de": "Stellpl\u00e4tze: 12",
-        "address_en": "Capacity: 12",
+        "popupContent": "Stellpl\u00e4tze: 12",
+        "popupContent_de": "Stellpl\u00e4tze: 12",
+        "popupContent_en": "Capacity: 12",
         "icon": {
           "id": "bikeParkCovIcon"
         }
@@ -953,9 +1037,9 @@
         "name_en": "Covered bike park",
         "name_de": "\u00dcberdachter Fahrradstellplatz",
         "name": "\u00dcberdachter Fahrradstellplatz",
-        "address": "Stellpl\u00e4tze: 30, Geb\u00fchrenpflichtig:: nein",
-        "address_de": "Stellpl\u00e4tze: 30, Geb\u00fchrenpflichtig:: nein",
-        "address_en": "Capacity: 30, Fee: no",
+        "popupContent": "Stellpl\u00e4tze: 30, Geb\u00fchrenpflichtig: nein",
+        "popupContent_de": "Stellpl\u00e4tze: 30, Geb\u00fchrenpflichtig: nein",
+        "popupContent_en": "Capacity: 30, Fee: no",
         "icon": {
           "id": "bikeParkCovIcon"
         }
@@ -974,30 +1058,9 @@
         "name_en": "Covered bike park",
         "name_de": "\u00dcberdachter Fahrradstellplatz",
         "name": "\u00dcberdachter Fahrradstellplatz",
-        "address": "Stellpl\u00e4tze: 48",
-        "address_de": "Stellpl\u00e4tze: 48",
-        "address_en": "Capacity: 48",
-        "icon": {
-          "id": "bikeParkCovIcon"
-        }
-      },
-      "geometry": {
-        "type": "Point",
-        "coordinates": [
-          8.9453099,
-          48.6628131
-        ]
-      }
-    },
-    {
-      "type": "Feature",
-      "properties": {
-        "name_en": "Covered bike park",
-        "name_de": "\u00dcberdachter Fahrradstellplatz",
-        "name": "\u00dcberdachter Fahrradstellplatz",
-        "address": "Stellpl\u00e4tze: 30",
-        "address_de": "Stellpl\u00e4tze: 30",
-        "address_en": "Capacity: 30",
+        "popupContent": "Stellpl\u00e4tze: 30",
+        "popupContent_de": "Stellpl\u00e4tze: 30",
+        "popupContent_en": "Capacity: 30",
         "icon": {
           "id": "bikeParkCovIcon"
         }
@@ -1016,9 +1079,9 @@
         "name_en": "Covered bike park",
         "name_de": "\u00dcberdachter Fahrradstellplatz",
         "name": "\u00dcberdachter Fahrradstellplatz",
-        "address": "Geb\u00fchrenpflichtig:: nein",
-        "address_de": "Geb\u00fchrenpflichtig:: nein",
-        "address_en": "Fee: no",
+        "popupContent": "Geb\u00fchrenpflichtig: nein",
+        "popupContent_de": "Geb\u00fchrenpflichtig: nein",
+        "popupContent_en": "Fee: no",
         "icon": {
           "id": "bikeParkCovIcon"
         }
@@ -1037,9 +1100,9 @@
         "name_en": "Covered bike park",
         "name_de": "\u00dcberdachter Fahrradstellplatz",
         "name": "\u00dcberdachter Fahrradstellplatz",
-        "address": "Stellpl\u00e4tze: 24, Geb\u00fchrenpflichtig:: nein",
-        "address_de": "Stellpl\u00e4tze: 24, Geb\u00fchrenpflichtig:: nein",
-        "address_en": "Capacity: 24, Fee: no",
+        "popupContent": "Stellpl\u00e4tze: 24, Geb\u00fchrenpflichtig: nein",
+        "popupContent_de": "Stellpl\u00e4tze: 24, Geb\u00fchrenpflichtig: nein",
+        "popupContent_en": "Capacity: 24, Fee: no",
         "icon": {
           "id": "bikeParkCovIcon"
         }
@@ -1058,9 +1121,9 @@
         "name_en": "Covered bike park",
         "name_de": "\u00dcberdachter Fahrradstellplatz",
         "name": "\u00dcberdachter Fahrradstellplatz",
-        "address": "Stellpl\u00e4tze: 20, Geb\u00fchrenpflichtig:: nein",
-        "address_de": "Stellpl\u00e4tze: 20, Geb\u00fchrenpflichtig:: nein",
-        "address_en": "Capacity: 20, Fee: no",
+        "popupContent": "Stellpl\u00e4tze: 20, Geb\u00fchrenpflichtig: nein",
+        "popupContent_de": "Stellpl\u00e4tze: 20, Geb\u00fchrenpflichtig: nein",
+        "popupContent_en": "Capacity: 20, Fee: no",
         "icon": {
           "id": "bikeParkCovIcon"
         }
@@ -1079,9 +1142,9 @@
         "name_en": "Covered bike park",
         "name_de": "\u00dcberdachter Fahrradstellplatz",
         "name": "\u00dcberdachter Fahrradstellplatz",
-        "address": "Stellpl\u00e4tze: 24, Geb\u00fchrenpflichtig:: nein",
-        "address_de": "Stellpl\u00e4tze: 24, Geb\u00fchrenpflichtig:: nein",
-        "address_en": "Capacity: 24, Fee: no",
+        "popupContent": "Stellpl\u00e4tze: 24, Geb\u00fchrenpflichtig: nein",
+        "popupContent_de": "Stellpl\u00e4tze: 24, Geb\u00fchrenpflichtig: nein",
+        "popupContent_en": "Capacity: 24, Fee: no",
         "icon": {
           "id": "bikeParkCovIcon"
         }
@@ -1100,9 +1163,9 @@
         "name_en": "Covered bike park",
         "name_de": "\u00dcberdachter Fahrradstellplatz",
         "name": "\u00dcberdachter Fahrradstellplatz",
-        "address": "Stellpl\u00e4tze: 20",
-        "address_de": "Stellpl\u00e4tze: 20",
-        "address_en": "Capacity: 20",
+        "popupContent": "Stellpl\u00e4tze: 20",
+        "popupContent_de": "Stellpl\u00e4tze: 20",
+        "popupContent_en": "Capacity: 20",
         "icon": {
           "id": "bikeParkCovIcon"
         }
@@ -1121,9 +1184,9 @@
         "name_en": "Covered bike park",
         "name_de": "\u00dcberdachter Fahrradstellplatz",
         "name": "\u00dcberdachter Fahrradstellplatz",
-        "address": "Stellpl\u00e4tze: 28",
-        "address_de": "Stellpl\u00e4tze: 28",
-        "address_en": "Capacity: 28",
+        "popupContent": "Stellpl\u00e4tze: 28",
+        "popupContent_de": "Stellpl\u00e4tze: 28",
+        "popupContent_en": "Capacity: 28",
         "icon": {
           "id": "bikeParkCovIcon"
         }
@@ -1142,9 +1205,9 @@
         "name_en": "Covered bike park",
         "name_de": "\u00dcberdachter Fahrradstellplatz",
         "name": "\u00dcberdachter Fahrradstellplatz",
-        "address": "Stellpl\u00e4tze: 16",
-        "address_de": "Stellpl\u00e4tze: 16",
-        "address_en": "Capacity: 16",
+        "popupContent": "Stellpl\u00e4tze: 16",
+        "popupContent_de": "Stellpl\u00e4tze: 16",
+        "popupContent_en": "Capacity: 16",
         "icon": {
           "id": "bikeParkCovIcon"
         }
@@ -1163,9 +1226,9 @@
         "name_en": "Covered bike park",
         "name_de": "\u00dcberdachter Fahrradstellplatz",
         "name": "\u00dcberdachter Fahrradstellplatz",
-        "address": "Stellpl\u00e4tze: 14",
-        "address_de": "Stellpl\u00e4tze: 14",
-        "address_en": "Capacity: 14",
+        "popupContent": "Stellpl\u00e4tze: 14",
+        "popupContent_de": "Stellpl\u00e4tze: 14",
+        "popupContent_en": "Capacity: 14",
         "icon": {
           "id": "bikeParkCovIcon"
         }
@@ -1184,9 +1247,9 @@
         "name_en": "Covered bike park",
         "name_de": "\u00dcberdachter Fahrradstellplatz",
         "name": "\u00dcberdachter Fahrradstellplatz",
-        "address": "Stellpl\u00e4tze: 8",
-        "address_de": "Stellpl\u00e4tze: 8",
-        "address_en": "Capacity: 8",
+        "popupContent": "Stellpl\u00e4tze: 8",
+        "popupContent_de": "Stellpl\u00e4tze: 8",
+        "popupContent_en": "Capacity: 8",
         "icon": {
           "id": "bikeParkCovIcon"
         }
@@ -1205,9 +1268,9 @@
         "name_en": "Covered bike park",
         "name_de": "\u00dcberdachter Fahrradstellplatz",
         "name": "\u00dcberdachter Fahrradstellplatz",
-        "address": "Stellpl\u00e4tze: 6",
-        "address_de": "Stellpl\u00e4tze: 6",
-        "address_en": "Capacity: 6",
+        "popupContent": "Stellpl\u00e4tze: 6",
+        "popupContent_de": "Stellpl\u00e4tze: 6",
+        "popupContent_en": "Capacity: 6",
         "icon": {
           "id": "bikeParkCovIcon"
         }
@@ -1226,9 +1289,9 @@
         "name": "Edeka Dagersheim",
         "name_en": "Edeka Dagersheim",
         "name_de": "Edeka Dagersheim",
-        "address": "Stellpl\u00e4tze: 20",
-        "address_de": "Stellpl\u00e4tze: 20",
-        "address_en": "Capacity: 20",
+        "popupContent": "Stellpl\u00e4tze: 20",
+        "popupContent_de": "Stellpl\u00e4tze: 20",
+        "popupContent_en": "Capacity: 20",
         "icon": {
           "id": "bikeParkCovIcon"
         }
@@ -1247,9 +1310,9 @@
         "name_en": "Covered bike park",
         "name_de": "\u00dcberdachter Fahrradstellplatz",
         "name": "\u00dcberdachter Fahrradstellplatz",
-        "address": "Stellpl\u00e4tze: 12",
-        "address_de": "Stellpl\u00e4tze: 12",
-        "address_en": "Capacity: 12",
+        "popupContent": "Stellpl\u00e4tze: 12",
+        "popupContent_de": "Stellpl\u00e4tze: 12",
+        "popupContent_en": "Capacity: 12",
         "icon": {
           "id": "bikeParkCovIcon"
         }
@@ -1268,9 +1331,9 @@
         "name_en": "Covered bike park",
         "name_de": "\u00dcberdachter Fahrradstellplatz",
         "name": "\u00dcberdachter Fahrradstellplatz",
-        "address": "Stellpl\u00e4tze: 7",
-        "address_de": "Stellpl\u00e4tze: 7",
-        "address_en": "Capacity: 7",
+        "popupContent": "Stellpl\u00e4tze: 7",
+        "popupContent_de": "Stellpl\u00e4tze: 7",
+        "popupContent_en": "Capacity: 7",
         "icon": {
           "id": "bikeParkCovIcon"
         }
@@ -1289,9 +1352,9 @@
         "name_en": "Covered bike park",
         "name_de": "\u00dcberdachter Fahrradstellplatz",
         "name": "\u00dcberdachter Fahrradstellplatz",
-        "address": "Stellpl\u00e4tze: 3",
-        "address_de": "Stellpl\u00e4tze: 3",
-        "address_en": "Capacity: 3",
+        "popupContent": "Stellpl\u00e4tze: 3",
+        "popupContent_de": "Stellpl\u00e4tze: 3",
+        "popupContent_en": "Capacity: 3",
         "icon": {
           "id": "bikeParkCovIcon"
         }
@@ -1310,9 +1373,9 @@
         "name_en": "Covered bike park",
         "name_de": "\u00dcberdachter Fahrradstellplatz",
         "name": "\u00dcberdachter Fahrradstellplatz",
-        "address": "Stellpl\u00e4tze: 5",
-        "address_de": "Stellpl\u00e4tze: 5",
-        "address_en": "Capacity: 5",
+        "popupContent": "Stellpl\u00e4tze: 5",
+        "popupContent_de": "Stellpl\u00e4tze: 5",
+        "popupContent_en": "Capacity: 5",
         "icon": {
           "id": "bikeParkCovIcon"
         }
@@ -1331,9 +1394,9 @@
         "name_en": "Covered bike park",
         "name_de": "\u00dcberdachter Fahrradstellplatz",
         "name": "\u00dcberdachter Fahrradstellplatz",
-        "address": "Stellpl\u00e4tze: 25",
-        "address_de": "Stellpl\u00e4tze: 25",
-        "address_en": "Capacity: 25",
+        "popupContent": "Stellpl\u00e4tze: 25",
+        "popupContent_de": "Stellpl\u00e4tze: 25",
+        "popupContent_en": "Capacity: 25",
         "icon": {
           "id": "bikeParkCovIcon"
         }
@@ -1352,9 +1415,9 @@
         "name_en": "Covered bike park",
         "name_de": "\u00dcberdachter Fahrradstellplatz",
         "name": "\u00dcberdachter Fahrradstellplatz",
-        "address": "Stellpl\u00e4tze: 10",
-        "address_de": "Stellpl\u00e4tze: 10",
-        "address_en": "Capacity: 10",
+        "popupContent": "Stellpl\u00e4tze: 10",
+        "popupContent_de": "Stellpl\u00e4tze: 10",
+        "popupContent_en": "Capacity: 10",
         "icon": {
           "id": "bikeParkCovIcon"
         }
@@ -1370,15 +1433,57 @@
     {
       "type": "Feature",
       "properties": {
+        "name_en": "Covered bike park",
+        "name_de": "\u00dcberdachter Fahrradstellplatz",
+        "name": "\u00dcberdachter Fahrradstellplatz",
+        "popupContent": "Stellpl\u00e4tze: 8",
+        "popupContent_de": "Stellpl\u00e4tze: 8",
+        "popupContent_en": "Capacity: 8",
+        "icon": {
+          "id": "bikeParkCovIcon"
+        }
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          8.9144085,
+          48.642879
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "name_en": "Covered bike park",
+        "name_de": "\u00dcberdachter Fahrradstellplatz",
+        "name": "\u00dcberdachter Fahrradstellplatz",
+        "popupContent": "Stellpl\u00e4tze: 12",
+        "popupContent_de": "Stellpl\u00e4tze: 12",
+        "popupContent_en": "Capacity: 12",
+        "icon": {
+          "id": "bikeParkCovIcon"
+        }
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          8.9393038,
+          48.6614065
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
         "name_en": "Open-air bike park",
         "name_de": "Fahrradstellplatz",
         "name": "Fahrradstellplatz",
-        "address": "",
-        "address_de": "",
-        "address_en": "",
+        "popupContent": "",
+        "popupContent_de": "",
+        "popupContent_en": "",
         "icon": {
           "id": "bikeParkOpIcon",
-          "svg": "<svg xmlns=\"http://www.w3.org/2000/svg\" id=\"Ebene_1\" data-name=\"Ebene 1\" viewBox=\"0 0 32.53 32.53\">\n  <defs>\n    <style>\n      .cls-2{fill:#fff}\n    </style>\n  </defs>\n  <path fill=\"#005ab4\" d=\"M699.51 384.05a16.27 16.27 0 11-16.27-16.27 16.27 16.27 0 0116.27 16.27\" transform=\"translate(-666.98 -367.78)\"/>\n  <path d=\"M687.7 374.17a3 3 0 00-3.18-3h-3.73v9.64h1.88v-3.63h1.85a3 3 0 003.18-3m-1.88 0a1.27 1.27 0 01-1.39 1.31h-1.76v-2.64h1.76a1.28 1.28 0 011.39 1.33M685.88 384.17a1.47 1.47 0 01-1.06-.44 1.38 1.38 0 01-.45-1 1.54 1.54 0 011.51-1.51 1.42 1.42 0 011 .45 1.5 1.5 0 01.43 1.06 1.49 1.49 0 01-1.47 1.47zm-7.88 4.89a3.55 3.55 0 012.65 1.09 3.62 3.62 0 011.07 2.67 3.66 3.66 0 01-3.72 3.72 3.62 3.62 0 01-2.67-1.07 3.55 3.55 0 01-1.09-2.65 3.72 3.72 0 013.76-3.76zm0 6.36a2.59 2.59 0 002.6-2.6 2.53 2.53 0 00-.76-1.86 2.46 2.46 0 00-1.84-.78 2.66 2.66 0 00-2.64 2.64 2.46 2.46 0 00.78 1.84 2.53 2.53 0 001.86.76zm4.32-7.49l1.65 1.73v4.63h-1.47v-3.72l-2.43-2.11a1.18 1.18 0 01-.42-1 1.45 1.45 0 01.42-1.06l2.11-2.11a1.18 1.18 0 011-.42 1.87 1.87 0 011.2.42l1.44 1.45a3.68 3.68 0 002.67 1.12v1.51a5.2 5.2 0 01-3.8-1.58l-.59-.6zm6.15 1.13a3.72 3.72 0 013.76 3.76 3.55 3.55 0 01-1.09 2.65 3.65 3.65 0 01-2.67 1.07 3.67 3.67 0 01-3.73-3.72 3.63 3.63 0 011.08-2.67 3.55 3.55 0 012.66-1.09zm0 6.36a2.53 2.53 0 001.86-.76 2.45 2.45 0 00.77-1.84 2.62 2.62 0 00-4.48-1.86 2.56 2.56 0 00-.75 1.86 2.58 2.58 0 002.6 2.6z\" class=\"cls-2\" transform=\"translate(-666.98 -367.78)\"/>\n</svg>"
+          "svg": "<svg xmlns=\"http://www.w3.org/2000/svg\" id=\"Ebene_1\" data-name=\"Ebene 1\" viewBox=\"0 0 32.53 32.53\">  <defs>    <style>      .cls-2{fill:#fff}    </style>  </defs>  <path fill=\"#005ab4\" d=\"M699.51 384.05a16.27 16.27 0 11-16.27-16.27 16.27 16.27 0 0116.27 16.27\" transform=\"translate(-666.98 -367.78)\"/>  <path d=\"M687.7 374.17a3 3 0 00-3.18-3h-3.73v9.64h1.88v-3.63h1.85a3 3 0 003.18-3m-1.88 0a1.27 1.27 0 01-1.39 1.31h-1.76v-2.64h1.76a1.28 1.28 0 011.39 1.33M685.88 384.17a1.47 1.47 0 01-1.06-.44 1.38 1.38 0 01-.45-1 1.54 1.54 0 011.51-1.51 1.42 1.42 0 011 .45 1.5 1.5 0 01.43 1.06 1.49 1.49 0 01-1.47 1.47zm-7.88 4.89a3.55 3.55 0 012.65 1.09 3.62 3.62 0 011.07 2.67 3.66 3.66 0 01-3.72 3.72 3.62 3.62 0 01-2.67-1.07 3.55 3.55 0 01-1.09-2.65 3.72 3.72 0 013.76-3.76zm0 6.36a2.59 2.59 0 002.6-2.6 2.53 2.53 0 00-.76-1.86 2.46 2.46 0 00-1.84-.78 2.66 2.66 0 00-2.64 2.64 2.46 2.46 0 00.78 1.84 2.53 2.53 0 001.86.76zm4.32-7.49l1.65 1.73v4.63h-1.47v-3.72l-2.43-2.11a1.18 1.18 0 01-.42-1 1.45 1.45 0 01.42-1.06l2.11-2.11a1.18 1.18 0 011-.42 1.87 1.87 0 011.2.42l1.44 1.45a3.68 3.68 0 002.67 1.12v1.51a5.2 5.2 0 01-3.8-1.58l-.59-.6zm6.15 1.13a3.72 3.72 0 013.76 3.76 3.55 3.55 0 01-1.09 2.65 3.65 3.65 0 01-2.67 1.07 3.67 3.67 0 01-3.73-3.72 3.63 3.63 0 011.08-2.67 3.55 3.55 0 012.66-1.09zm0 6.36a2.53 2.53 0 001.86-.76 2.45 2.45 0 00.77-1.84 2.62 2.62 0 00-4.48-1.86 2.56 2.56 0 00-.75 1.86 2.58 2.58 0 002.6 2.6z\" class=\"cls-2\" transform=\"translate(-666.98 -367.78)\"/></svg>"
         }
       },
       "geometry": {
@@ -1395,9 +1500,9 @@
         "name_en": "Open-air bike park",
         "name_de": "Fahrradstellplatz",
         "name": "Fahrradstellplatz",
-        "address": "Stellpl\u00e4tze: 7",
-        "address_de": "Stellpl\u00e4tze: 7",
-        "address_en": "Capacity: 7",
+        "popupContent": "Stellpl\u00e4tze: 7",
+        "popupContent_de": "Stellpl\u00e4tze: 7",
+        "popupContent_en": "Capacity: 7",
         "icon": {
           "id": "bikeParkOpIcon"
         }
@@ -1416,9 +1521,51 @@
         "name_en": "Open-air bike park",
         "name_de": "Fahrradstellplatz",
         "name": "Fahrradstellplatz",
-        "address": "",
-        "address_de": "",
-        "address_en": "",
+        "popupContent": "Stellpl\u00e4tze: 6",
+        "popupContent_de": "Stellpl\u00e4tze: 6",
+        "popupContent_en": "Capacity: 6",
+        "icon": {
+          "id": "bikeParkOpIcon"
+        }
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          8.997639,
+          48.6880699
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "name_en": "Open-air bike park",
+        "name_de": "Fahrradstellplatz",
+        "name": "Fahrradstellplatz",
+        "popupContent": "Stellpl\u00e4tze: 6",
+        "popupContent_de": "Stellpl\u00e4tze: 6",
+        "popupContent_en": "Capacity: 6",
+        "icon": {
+          "id": "bikeParkOpIcon"
+        }
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          8.9940446,
+          48.6858405
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "name_en": "Open-air bike park",
+        "name_de": "Fahrradstellplatz",
+        "name": "Fahrradstellplatz",
+        "popupContent": "",
+        "popupContent_de": "",
+        "popupContent_en": "",
         "icon": {
           "id": "bikeParkOpIcon"
         }
@@ -1437,9 +1584,9 @@
         "name_en": "Open-air bike park",
         "name_de": "Fahrradstellplatz",
         "name": "Fahrradstellplatz",
-        "address": "Stellpl\u00e4tze: 18",
-        "address_de": "Stellpl\u00e4tze: 18",
-        "address_en": "Capacity: 18",
+        "popupContent": "Stellpl\u00e4tze: 18",
+        "popupContent_de": "Stellpl\u00e4tze: 18",
+        "popupContent_en": "Capacity: 18",
         "icon": {
           "id": "bikeParkOpIcon"
         }
@@ -1458,9 +1605,9 @@
         "name_en": "Open-air bike park",
         "name_de": "Fahrradstellplatz",
         "name": "Fahrradstellplatz",
-        "address": "Stellpl\u00e4tze: 48",
-        "address_de": "Stellpl\u00e4tze: 48",
-        "address_en": "Capacity: 48",
+        "popupContent": "Stellpl\u00e4tze: 48",
+        "popupContent_de": "Stellpl\u00e4tze: 48",
+        "popupContent_en": "Capacity: 48",
         "icon": {
           "id": "bikeParkOpIcon"
         }
@@ -1479,9 +1626,9 @@
         "name_en": "Open-air bike park",
         "name_de": "Fahrradstellplatz",
         "name": "Fahrradstellplatz",
-        "address": "Stellpl\u00e4tze: 6",
-        "address_de": "Stellpl\u00e4tze: 6",
-        "address_en": "Capacity: 6",
+        "popupContent": "Stellpl\u00e4tze: 6",
+        "popupContent_de": "Stellpl\u00e4tze: 6",
+        "popupContent_en": "Capacity: 6",
         "icon": {
           "id": "bikeParkOpIcon"
         }
@@ -1500,9 +1647,9 @@
         "name_en": "Open-air bike park",
         "name_de": "Fahrradstellplatz",
         "name": "Fahrradstellplatz",
-        "address": "Stellpl\u00e4tze: 4",
-        "address_de": "Stellpl\u00e4tze: 4",
-        "address_en": "Capacity: 4",
+        "popupContent": "Stellpl\u00e4tze: 4",
+        "popupContent_de": "Stellpl\u00e4tze: 4",
+        "popupContent_en": "Capacity: 4",
         "icon": {
           "id": "bikeParkOpIcon"
         }
@@ -1521,9 +1668,9 @@
         "name_en": "Open-air bike park",
         "name_de": "Fahrradstellplatz",
         "name": "Fahrradstellplatz",
-        "address": "Stellpl\u00e4tze: 10",
-        "address_de": "Stellpl\u00e4tze: 10",
-        "address_en": "Capacity: 10",
+        "popupContent": "Stellpl\u00e4tze: 10",
+        "popupContent_de": "Stellpl\u00e4tze: 10",
+        "popupContent_en": "Capacity: 10",
         "icon": {
           "id": "bikeParkOpIcon"
         }
@@ -1542,9 +1689,9 @@
         "name_en": "Open-air bike park",
         "name_de": "Fahrradstellplatz",
         "name": "Fahrradstellplatz",
-        "address": "Stellpl\u00e4tze: 3",
-        "address_de": "Stellpl\u00e4tze: 3",
-        "address_en": "Capacity: 3",
+        "popupContent": "Stellpl\u00e4tze: 3",
+        "popupContent_de": "Stellpl\u00e4tze: 3",
+        "popupContent_en": "Capacity: 3",
         "icon": {
           "id": "bikeParkOpIcon"
         }
@@ -1563,9 +1710,9 @@
         "name_en": "Open-air bike park",
         "name_de": "Fahrradstellplatz",
         "name": "Fahrradstellplatz",
-        "address": "Stellpl\u00e4tze: 5, Geb\u00fchrenpflichtig:: nein",
-        "address_de": "Stellpl\u00e4tze: 5, Geb\u00fchrenpflichtig:: nein",
-        "address_en": "Capacity: 5, Fee: no",
+        "popupContent": "Stellpl\u00e4tze: 5, Geb\u00fchrenpflichtig: nein",
+        "popupContent_de": "Stellpl\u00e4tze: 5, Geb\u00fchrenpflichtig: nein",
+        "popupContent_en": "Capacity: 5, Fee: no",
         "icon": {
           "id": "bikeParkOpIcon"
         }
@@ -1584,9 +1731,9 @@
         "name_en": "Open-air bike park",
         "name_de": "Fahrradstellplatz",
         "name": "Fahrradstellplatz",
-        "address": "Stellpl\u00e4tze: 9",
-        "address_de": "Stellpl\u00e4tze: 9",
-        "address_en": "Capacity: 9",
+        "popupContent": "Stellpl\u00e4tze: 9",
+        "popupContent_de": "Stellpl\u00e4tze: 9",
+        "popupContent_en": "Capacity: 9",
         "icon": {
           "id": "bikeParkOpIcon"
         }
@@ -1605,9 +1752,9 @@
         "name_en": "Open-air bike park",
         "name_de": "Fahrradstellplatz",
         "name": "Fahrradstellplatz",
-        "address": "Stellpl\u00e4tze: 58",
-        "address_de": "Stellpl\u00e4tze: 58",
-        "address_en": "Capacity: 58",
+        "popupContent": "Stellpl\u00e4tze: 58",
+        "popupContent_de": "Stellpl\u00e4tze: 58",
+        "popupContent_en": "Capacity: 58",
         "icon": {
           "id": "bikeParkOpIcon"
         }
@@ -1626,9 +1773,9 @@
         "name_en": "Open-air bike park",
         "name_de": "Fahrradstellplatz",
         "name": "Fahrradstellplatz",
-        "address": "Stellpl\u00e4tze: 18",
-        "address_de": "Stellpl\u00e4tze: 18",
-        "address_en": "Capacity: 18",
+        "popupContent": "Stellpl\u00e4tze: 18",
+        "popupContent_de": "Stellpl\u00e4tze: 18",
+        "popupContent_en": "Capacity: 18",
         "icon": {
           "id": "bikeParkOpIcon"
         }
@@ -1647,9 +1794,9 @@
         "name_en": "Open-air bike park",
         "name_de": "Fahrradstellplatz",
         "name": "Fahrradstellplatz",
-        "address": "Stellpl\u00e4tze: 8",
-        "address_de": "Stellpl\u00e4tze: 8",
-        "address_en": "Capacity: 8",
+        "popupContent": "Stellpl\u00e4tze: 8",
+        "popupContent_de": "Stellpl\u00e4tze: 8",
+        "popupContent_en": "Capacity: 8",
         "icon": {
           "id": "bikeParkOpIcon"
         }
@@ -1668,9 +1815,9 @@
         "name_en": "Open-air bike park",
         "name_de": "Fahrradstellplatz",
         "name": "Fahrradstellplatz",
-        "address": "Stellpl\u00e4tze: 6",
-        "address_de": "Stellpl\u00e4tze: 6",
-        "address_en": "Capacity: 6",
+        "popupContent": "Stellpl\u00e4tze: 6",
+        "popupContent_de": "Stellpl\u00e4tze: 6",
+        "popupContent_en": "Capacity: 6",
         "icon": {
           "id": "bikeParkOpIcon"
         }
@@ -1689,9 +1836,9 @@
         "name_en": "Open-air bike park",
         "name_de": "Fahrradstellplatz",
         "name": "Fahrradstellplatz",
-        "address": "Stellpl\u00e4tze: 8",
-        "address_de": "Stellpl\u00e4tze: 8",
-        "address_en": "Capacity: 8",
+        "popupContent": "Stellpl\u00e4tze: 8",
+        "popupContent_de": "Stellpl\u00e4tze: 8",
+        "popupContent_en": "Capacity: 8",
         "icon": {
           "id": "bikeParkOpIcon"
         }
@@ -1710,9 +1857,9 @@
         "name_en": "Open-air bike park",
         "name_de": "Fahrradstellplatz",
         "name": "Fahrradstellplatz",
-        "address": "Stellpl\u00e4tze: 4",
-        "address_de": "Stellpl\u00e4tze: 4",
-        "address_en": "Capacity: 4",
+        "popupContent": "Stellpl\u00e4tze: 4",
+        "popupContent_de": "Stellpl\u00e4tze: 4",
+        "popupContent_en": "Capacity: 4",
         "icon": {
           "id": "bikeParkOpIcon"
         }
@@ -1731,9 +1878,9 @@
         "name_en": "Open-air bike park",
         "name_de": "Fahrradstellplatz",
         "name": "Fahrradstellplatz",
-        "address": "Stellpl\u00e4tze: 8",
-        "address_de": "Stellpl\u00e4tze: 8",
-        "address_en": "Capacity: 8",
+        "popupContent": "Stellpl\u00e4tze: 8",
+        "popupContent_de": "Stellpl\u00e4tze: 8",
+        "popupContent_en": "Capacity: 8",
         "icon": {
           "id": "bikeParkOpIcon"
         }
@@ -1752,9 +1899,9 @@
         "name_en": "Open-air bike park",
         "name_de": "Fahrradstellplatz",
         "name": "Fahrradstellplatz",
-        "address": "Stellpl\u00e4tze: 2",
-        "address_de": "Stellpl\u00e4tze: 2",
-        "address_en": "Capacity: 2",
+        "popupContent": "Stellpl\u00e4tze: 2",
+        "popupContent_de": "Stellpl\u00e4tze: 2",
+        "popupContent_en": "Capacity: 2",
         "icon": {
           "id": "bikeParkOpIcon"
         }
@@ -1773,9 +1920,9 @@
         "name_en": "Open-air bike park",
         "name_de": "Fahrradstellplatz",
         "name": "Fahrradstellplatz",
-        "address": "Stellpl\u00e4tze: 12",
-        "address_de": "Stellpl\u00e4tze: 12",
-        "address_en": "Capacity: 12",
+        "popupContent": "Stellpl\u00e4tze: 12",
+        "popupContent_de": "Stellpl\u00e4tze: 12",
+        "popupContent_en": "Capacity: 12",
         "icon": {
           "id": "bikeParkOpIcon"
         }
@@ -1794,9 +1941,9 @@
         "name_en": "Open-air bike park",
         "name_de": "Fahrradstellplatz",
         "name": "Fahrradstellplatz",
-        "address": "Stellpl\u00e4tze: 34",
-        "address_de": "Stellpl\u00e4tze: 34",
-        "address_en": "Capacity: 34",
+        "popupContent": "Stellpl\u00e4tze: 34",
+        "popupContent_de": "Stellpl\u00e4tze: 34",
+        "popupContent_en": "Capacity: 34",
         "icon": {
           "id": "bikeParkOpIcon"
         }
@@ -1815,9 +1962,9 @@
         "name_en": "Open-air bike park",
         "name_de": "Fahrradstellplatz",
         "name": "Fahrradstellplatz",
-        "address": "Stellpl\u00e4tze: 2",
-        "address_de": "Stellpl\u00e4tze: 2",
-        "address_en": "Capacity: 2",
+        "popupContent": "Stellpl\u00e4tze: 2",
+        "popupContent_de": "Stellpl\u00e4tze: 2",
+        "popupContent_en": "Capacity: 2",
         "icon": {
           "id": "bikeParkOpIcon"
         }
@@ -1836,9 +1983,9 @@
         "name_en": "Open-air bike park",
         "name_de": "Fahrradstellplatz",
         "name": "Fahrradstellplatz",
-        "address": "Stellpl\u00e4tze: 2",
-        "address_de": "Stellpl\u00e4tze: 2",
-        "address_en": "Capacity: 2",
+        "popupContent": "Stellpl\u00e4tze: 2",
+        "popupContent_de": "Stellpl\u00e4tze: 2",
+        "popupContent_en": "Capacity: 2",
         "icon": {
           "id": "bikeParkOpIcon"
         }
@@ -1857,9 +2004,9 @@
         "name_en": "Open-air bike park",
         "name_de": "Fahrradstellplatz",
         "name": "Fahrradstellplatz",
-        "address": "Stellpl\u00e4tze: 8",
-        "address_de": "Stellpl\u00e4tze: 8",
-        "address_en": "Capacity: 8",
+        "popupContent": "Stellpl\u00e4tze: 8",
+        "popupContent_de": "Stellpl\u00e4tze: 8",
+        "popupContent_en": "Capacity: 8",
         "icon": {
           "id": "bikeParkOpIcon"
         }
@@ -1878,9 +2025,9 @@
         "name_en": "Open-air bike park",
         "name_de": "Fahrradstellplatz",
         "name": "Fahrradstellplatz",
-        "address": "Stellpl\u00e4tze: 8",
-        "address_de": "Stellpl\u00e4tze: 8",
-        "address_en": "Capacity: 8",
+        "popupContent": "Stellpl\u00e4tze: 8",
+        "popupContent_de": "Stellpl\u00e4tze: 8",
+        "popupContent_en": "Capacity: 8",
         "icon": {
           "id": "bikeParkOpIcon"
         }
@@ -1899,9 +2046,9 @@
         "name_en": "Open-air bike park",
         "name_de": "Fahrradstellplatz",
         "name": "Fahrradstellplatz",
-        "address": "Stellpl\u00e4tze: 20",
-        "address_de": "Stellpl\u00e4tze: 20",
-        "address_en": "Capacity: 20",
+        "popupContent": "Stellpl\u00e4tze: 20",
+        "popupContent_de": "Stellpl\u00e4tze: 20",
+        "popupContent_en": "Capacity: 20",
         "icon": {
           "id": "bikeParkOpIcon"
         }
@@ -1920,9 +2067,9 @@
         "name_en": "Open-air bike park",
         "name_de": "Fahrradstellplatz",
         "name": "Fahrradstellplatz",
-        "address": "Stellpl\u00e4tze: 2",
-        "address_de": "Stellpl\u00e4tze: 2",
-        "address_en": "Capacity: 2",
+        "popupContent": "Stellpl\u00e4tze: 2",
+        "popupContent_de": "Stellpl\u00e4tze: 2",
+        "popupContent_en": "Capacity: 2",
         "icon": {
           "id": "bikeParkOpIcon"
         }
@@ -1941,9 +2088,9 @@
         "name_en": "Open-air bike park",
         "name_de": "Fahrradstellplatz",
         "name": "Fahrradstellplatz",
-        "address": "Stellpl\u00e4tze: 4",
-        "address_de": "Stellpl\u00e4tze: 4",
-        "address_en": "Capacity: 4",
+        "popupContent": "Stellpl\u00e4tze: 4",
+        "popupContent_de": "Stellpl\u00e4tze: 4",
+        "popupContent_en": "Capacity: 4",
         "icon": {
           "id": "bikeParkOpIcon"
         }
@@ -1962,9 +2109,9 @@
         "name_en": "Open-air bike park",
         "name_de": "Fahrradstellplatz",
         "name": "Fahrradstellplatz",
-        "address": "Stellpl\u00e4tze: 10, Geb\u00fchrenpflichtig:: nein",
-        "address_de": "Stellpl\u00e4tze: 10, Geb\u00fchrenpflichtig:: nein",
-        "address_en": "Capacity: 10, Fee: no",
+        "popupContent": "Stellpl\u00e4tze: 10, Geb\u00fchrenpflichtig: nein",
+        "popupContent_de": "Stellpl\u00e4tze: 10, Geb\u00fchrenpflichtig: nein",
+        "popupContent_en": "Capacity: 10, Fee: no",
         "icon": {
           "id": "bikeParkOpIcon"
         }
@@ -1983,9 +2130,9 @@
         "name_en": "Open-air bike park",
         "name_de": "Fahrradstellplatz",
         "name": "Fahrradstellplatz",
-        "address": "Stellpl\u00e4tze: 10",
-        "address_de": "Stellpl\u00e4tze: 10",
-        "address_en": "Capacity: 10",
+        "popupContent": "Stellpl\u00e4tze: 10",
+        "popupContent_de": "Stellpl\u00e4tze: 10",
+        "popupContent_en": "Capacity: 10",
         "icon": {
           "id": "bikeParkOpIcon"
         }
@@ -2004,9 +2151,9 @@
         "name_en": "Open-air bike park",
         "name_de": "Fahrradstellplatz",
         "name": "Fahrradstellplatz",
-        "address": "Stellpl\u00e4tze: 6",
-        "address_de": "Stellpl\u00e4tze: 6",
-        "address_en": "Capacity: 6",
+        "popupContent": "Stellpl\u00e4tze: 6",
+        "popupContent_de": "Stellpl\u00e4tze: 6",
+        "popupContent_en": "Capacity: 6",
         "icon": {
           "id": "bikeParkOpIcon"
         }
@@ -2025,9 +2172,9 @@
         "name_en": "Open-air bike park",
         "name_de": "Fahrradstellplatz",
         "name": "Fahrradstellplatz",
-        "address": "Stellpl\u00e4tze: 100",
-        "address_de": "Stellpl\u00e4tze: 100",
-        "address_en": "Capacity: 100",
+        "popupContent": "Stellpl\u00e4tze: 100",
+        "popupContent_de": "Stellpl\u00e4tze: 100",
+        "popupContent_en": "Capacity: 100",
         "icon": {
           "id": "bikeParkOpIcon"
         }
@@ -2046,9 +2193,9 @@
         "name_en": "Open-air bike park",
         "name_de": "Fahrradstellplatz",
         "name": "Fahrradstellplatz",
-        "address": "Stellpl\u00e4tze: 6",
-        "address_de": "Stellpl\u00e4tze: 6",
-        "address_en": "Capacity: 6",
+        "popupContent": "Stellpl\u00e4tze: 6",
+        "popupContent_de": "Stellpl\u00e4tze: 6",
+        "popupContent_en": "Capacity: 6",
         "icon": {
           "id": "bikeParkOpIcon"
         }
@@ -2067,9 +2214,9 @@
         "name_en": "Open-air bike park",
         "name_de": "Fahrradstellplatz",
         "name": "Fahrradstellplatz",
-        "address": "Stellpl\u00e4tze: 42",
-        "address_de": "Stellpl\u00e4tze: 42",
-        "address_en": "Capacity: 42",
+        "popupContent": "Stellpl\u00e4tze: 42",
+        "popupContent_de": "Stellpl\u00e4tze: 42",
+        "popupContent_en": "Capacity: 42",
         "icon": {
           "id": "bikeParkOpIcon"
         }
@@ -2088,9 +2235,9 @@
         "name_en": "Open-air bike park",
         "name_de": "Fahrradstellplatz",
         "name": "Fahrradstellplatz",
-        "address": "Stellpl\u00e4tze: 10",
-        "address_de": "Stellpl\u00e4tze: 10",
-        "address_en": "Capacity: 10",
+        "popupContent": "Stellpl\u00e4tze: 10",
+        "popupContent_de": "Stellpl\u00e4tze: 10",
+        "popupContent_en": "Capacity: 10",
         "icon": {
           "id": "bikeParkOpIcon"
         }
@@ -2109,9 +2256,9 @@
         "name_en": "Open-air bike park",
         "name_de": "Fahrradstellplatz",
         "name": "Fahrradstellplatz",
-        "address": "Stellpl\u00e4tze: 28",
-        "address_de": "Stellpl\u00e4tze: 28",
-        "address_en": "Capacity: 28",
+        "popupContent": "Stellpl\u00e4tze: 28",
+        "popupContent_de": "Stellpl\u00e4tze: 28",
+        "popupContent_en": "Capacity: 28",
         "icon": {
           "id": "bikeParkOpIcon"
         }
@@ -2130,9 +2277,9 @@
         "name_en": "Open-air bike park",
         "name_de": "Fahrradstellplatz",
         "name": "Fahrradstellplatz",
-        "address": "Stellpl\u00e4tze: 16",
-        "address_de": "Stellpl\u00e4tze: 16",
-        "address_en": "Capacity: 16",
+        "popupContent": "Stellpl\u00e4tze: 16",
+        "popupContent_de": "Stellpl\u00e4tze: 16",
+        "popupContent_en": "Capacity: 16",
         "icon": {
           "id": "bikeParkOpIcon"
         }
@@ -2151,9 +2298,9 @@
         "name_en": "Open-air bike park",
         "name_de": "Fahrradstellplatz",
         "name": "Fahrradstellplatz",
-        "address": "Stellpl\u00e4tze: 24",
-        "address_de": "Stellpl\u00e4tze: 24",
-        "address_en": "Capacity: 24",
+        "popupContent": "Stellpl\u00e4tze: 24",
+        "popupContent_de": "Stellpl\u00e4tze: 24",
+        "popupContent_en": "Capacity: 24",
         "icon": {
           "id": "bikeParkOpIcon"
         }
@@ -2172,9 +2319,9 @@
         "name_en": "Open-air bike park",
         "name_de": "Fahrradstellplatz",
         "name": "Fahrradstellplatz",
-        "address": "Stellpl\u00e4tze: 8",
-        "address_de": "Stellpl\u00e4tze: 8",
-        "address_en": "Capacity: 8",
+        "popupContent": "Stellpl\u00e4tze: 8",
+        "popupContent_de": "Stellpl\u00e4tze: 8",
+        "popupContent_en": "Capacity: 8",
         "icon": {
           "id": "bikeParkOpIcon"
         }
@@ -2193,9 +2340,9 @@
         "name_en": "Open-air bike park",
         "name_de": "Fahrradstellplatz",
         "name": "Fahrradstellplatz",
-        "address": "Stellpl\u00e4tze: 4",
-        "address_de": "Stellpl\u00e4tze: 4",
-        "address_en": "Capacity: 4",
+        "popupContent": "Stellpl\u00e4tze: 4",
+        "popupContent_de": "Stellpl\u00e4tze: 4",
+        "popupContent_en": "Capacity: 4",
         "icon": {
           "id": "bikeParkOpIcon"
         }
@@ -2214,9 +2361,9 @@
         "name_en": "Open-air bike park",
         "name_de": "Fahrradstellplatz",
         "name": "Fahrradstellplatz",
-        "address": "Stellpl\u00e4tze: 12",
-        "address_de": "Stellpl\u00e4tze: 12",
-        "address_en": "Capacity: 12",
+        "popupContent": "Stellpl\u00e4tze: 12",
+        "popupContent_de": "Stellpl\u00e4tze: 12",
+        "popupContent_en": "Capacity: 12",
         "icon": {
           "id": "bikeParkOpIcon"
         }
@@ -2235,9 +2382,9 @@
         "name_en": "Open-air bike park",
         "name_de": "Fahrradstellplatz",
         "name": "Fahrradstellplatz",
-        "address": "Stellpl\u00e4tze: 6",
-        "address_de": "Stellpl\u00e4tze: 6",
-        "address_en": "Capacity: 6",
+        "popupContent": "Stellpl\u00e4tze: 6",
+        "popupContent_de": "Stellpl\u00e4tze: 6",
+        "popupContent_en": "Capacity: 6",
         "icon": {
           "id": "bikeParkOpIcon"
         }
@@ -2256,9 +2403,9 @@
         "name_en": "Open-air bike park",
         "name_de": "Fahrradstellplatz",
         "name": "Fahrradstellplatz",
-        "address": "Stellpl\u00e4tze: 4",
-        "address_de": "Stellpl\u00e4tze: 4",
-        "address_en": "Capacity: 4",
+        "popupContent": "Stellpl\u00e4tze: 4",
+        "popupContent_de": "Stellpl\u00e4tze: 4",
+        "popupContent_en": "Capacity: 4",
         "icon": {
           "id": "bikeParkOpIcon"
         }
@@ -2277,9 +2424,9 @@
         "name_en": "Open-air bike park",
         "name_de": "Fahrradstellplatz",
         "name": "Fahrradstellplatz",
-        "address": "Stellpl\u00e4tze: 34",
-        "address_de": "Stellpl\u00e4tze: 34",
-        "address_en": "Capacity: 34",
+        "popupContent": "Stellpl\u00e4tze: 34",
+        "popupContent_de": "Stellpl\u00e4tze: 34",
+        "popupContent_en": "Capacity: 34",
         "icon": {
           "id": "bikeParkOpIcon"
         }
@@ -2298,9 +2445,9 @@
         "name_en": "Open-air bike park",
         "name_de": "Fahrradstellplatz",
         "name": "Fahrradstellplatz",
-        "address": "Stellpl\u00e4tze: 10",
-        "address_de": "Stellpl\u00e4tze: 10",
-        "address_en": "Capacity: 10",
+        "popupContent": "Stellpl\u00e4tze: 10",
+        "popupContent_de": "Stellpl\u00e4tze: 10",
+        "popupContent_en": "Capacity: 10",
         "icon": {
           "id": "bikeParkOpIcon"
         }
@@ -2319,9 +2466,9 @@
         "name_en": "Open-air bike park",
         "name_de": "Fahrradstellplatz",
         "name": "Fahrradstellplatz",
-        "address": "Stellpl\u00e4tze: 10",
-        "address_de": "Stellpl\u00e4tze: 10",
-        "address_en": "Capacity: 10",
+        "popupContent": "Stellpl\u00e4tze: 10",
+        "popupContent_de": "Stellpl\u00e4tze: 10",
+        "popupContent_en": "Capacity: 10",
         "icon": {
           "id": "bikeParkOpIcon"
         }
@@ -2340,9 +2487,9 @@
         "name_en": "Open-air bike park",
         "name_de": "Fahrradstellplatz",
         "name": "Fahrradstellplatz",
-        "address": "Stellpl\u00e4tze: 10",
-        "address_de": "Stellpl\u00e4tze: 10",
-        "address_en": "Capacity: 10",
+        "popupContent": "Stellpl\u00e4tze: 10",
+        "popupContent_de": "Stellpl\u00e4tze: 10",
+        "popupContent_en": "Capacity: 10",
         "icon": {
           "id": "bikeParkOpIcon"
         }
@@ -2361,9 +2508,9 @@
         "name_en": "Open-air bike park",
         "name_de": "Fahrradstellplatz",
         "name": "Fahrradstellplatz",
-        "address": "Stellpl\u00e4tze: 50",
-        "address_de": "Stellpl\u00e4tze: 50",
-        "address_en": "Capacity: 50",
+        "popupContent": "Stellpl\u00e4tze: 50",
+        "popupContent_de": "Stellpl\u00e4tze: 50",
+        "popupContent_en": "Capacity: 50",
         "icon": {
           "id": "bikeParkOpIcon"
         }
@@ -2382,9 +2529,9 @@
         "name_en": "Open-air bike park",
         "name_de": "Fahrradstellplatz",
         "name": "Fahrradstellplatz",
-        "address": "Stellpl\u00e4tze: 8",
-        "address_de": "Stellpl\u00e4tze: 8",
-        "address_en": "Capacity: 8",
+        "popupContent": "Stellpl\u00e4tze: 8",
+        "popupContent_de": "Stellpl\u00e4tze: 8",
+        "popupContent_en": "Capacity: 8",
         "icon": {
           "id": "bikeParkOpIcon"
         }
@@ -2403,9 +2550,9 @@
         "name_en": "Open-air bike park",
         "name_de": "Fahrradstellplatz",
         "name": "Fahrradstellplatz",
-        "address": "Stellpl\u00e4tze: 20",
-        "address_de": "Stellpl\u00e4tze: 20",
-        "address_en": "Capacity: 20",
+        "popupContent": "Stellpl\u00e4tze: 20",
+        "popupContent_de": "Stellpl\u00e4tze: 20",
+        "popupContent_en": "Capacity: 20",
         "icon": {
           "id": "bikeParkOpIcon"
         }
@@ -2424,9 +2571,9 @@
         "name_en": "Open-air bike park",
         "name_de": "Fahrradstellplatz",
         "name": "Fahrradstellplatz",
-        "address": "Stellpl\u00e4tze: 14, Geb\u00fchrenpflichtig:: nein",
-        "address_de": "Stellpl\u00e4tze: 14, Geb\u00fchrenpflichtig:: nein",
-        "address_en": "Capacity: 14, Fee: no",
+        "popupContent": "Stellpl\u00e4tze: 14, Geb\u00fchrenpflichtig: nein",
+        "popupContent_de": "Stellpl\u00e4tze: 14, Geb\u00fchrenpflichtig: nein",
+        "popupContent_en": "Capacity: 14, Fee: no",
         "icon": {
           "id": "bikeParkOpIcon"
         }
@@ -2445,9 +2592,9 @@
         "name_en": "Open-air bike park",
         "name_de": "Fahrradstellplatz",
         "name": "Fahrradstellplatz",
-        "address": "Stellpl\u00e4tze: 10, Geb\u00fchrenpflichtig:: nein",
-        "address_de": "Stellpl\u00e4tze: 10, Geb\u00fchrenpflichtig:: nein",
-        "address_en": "Capacity: 10, Fee: no",
+        "popupContent": "Stellpl\u00e4tze: 10, Geb\u00fchrenpflichtig: nein",
+        "popupContent_de": "Stellpl\u00e4tze: 10, Geb\u00fchrenpflichtig: nein",
+        "popupContent_en": "Capacity: 10, Fee: no",
         "icon": {
           "id": "bikeParkOpIcon"
         }
@@ -2466,9 +2613,9 @@
         "name_en": "Open-air bike park",
         "name_de": "Fahrradstellplatz",
         "name": "Fahrradstellplatz",
-        "address": "Stellpl\u00e4tze: 4, Geb\u00fchrenpflichtig:: nein",
-        "address_de": "Stellpl\u00e4tze: 4, Geb\u00fchrenpflichtig:: nein",
-        "address_en": "Capacity: 4, Fee: no",
+        "popupContent": "Stellpl\u00e4tze: 4, Geb\u00fchrenpflichtig: nein",
+        "popupContent_de": "Stellpl\u00e4tze: 4, Geb\u00fchrenpflichtig: nein",
+        "popupContent_en": "Capacity: 4, Fee: no",
         "icon": {
           "id": "bikeParkOpIcon"
         }
@@ -2487,9 +2634,9 @@
         "name_en": "Open-air bike park",
         "name_de": "Fahrradstellplatz",
         "name": "Fahrradstellplatz",
-        "address": "Stellpl\u00e4tze: 5, Geb\u00fchrenpflichtig:: nein",
-        "address_de": "Stellpl\u00e4tze: 5, Geb\u00fchrenpflichtig:: nein",
-        "address_en": "Capacity: 5, Fee: no",
+        "popupContent": "Stellpl\u00e4tze: 5, Geb\u00fchrenpflichtig: nein",
+        "popupContent_de": "Stellpl\u00e4tze: 5, Geb\u00fchrenpflichtig: nein",
+        "popupContent_en": "Capacity: 5, Fee: no",
         "icon": {
           "id": "bikeParkOpIcon"
         }
@@ -2508,9 +2655,9 @@
         "name_en": "Open-air bike park",
         "name_de": "Fahrradstellplatz",
         "name": "Fahrradstellplatz",
-        "address": "Stellpl\u00e4tze: 8",
-        "address_de": "Stellpl\u00e4tze: 8",
-        "address_en": "Capacity: 8",
+        "popupContent": "Stellpl\u00e4tze: 8",
+        "popupContent_de": "Stellpl\u00e4tze: 8",
+        "popupContent_en": "Capacity: 8",
         "icon": {
           "id": "bikeParkOpIcon"
         }
@@ -2529,9 +2676,9 @@
         "name_en": "Open-air bike park",
         "name_de": "Fahrradstellplatz",
         "name": "Fahrradstellplatz",
-        "address": "Stellpl\u00e4tze: 20",
-        "address_de": "Stellpl\u00e4tze: 20",
-        "address_en": "Capacity: 20",
+        "popupContent": "Stellpl\u00e4tze: 20",
+        "popupContent_de": "Stellpl\u00e4tze: 20",
+        "popupContent_en": "Capacity: 20",
         "icon": {
           "id": "bikeParkOpIcon"
         }
@@ -2550,9 +2697,9 @@
         "name_en": "Open-air bike park",
         "name_de": "Fahrradstellplatz",
         "name": "Fahrradstellplatz",
-        "address": "",
-        "address_de": "",
-        "address_en": "",
+        "popupContent": "",
+        "popupContent_de": "",
+        "popupContent_en": "",
         "icon": {
           "id": "bikeParkOpIcon"
         }
@@ -2571,9 +2718,9 @@
         "name_en": "Open-air bike park",
         "name_de": "Fahrradstellplatz",
         "name": "Fahrradstellplatz",
-        "address": "",
-        "address_de": "",
-        "address_en": "",
+        "popupContent": "",
+        "popupContent_de": "",
+        "popupContent_en": "",
         "icon": {
           "id": "bikeParkOpIcon"
         }
@@ -2592,9 +2739,9 @@
         "name_en": "Open-air bike park",
         "name_de": "Fahrradstellplatz",
         "name": "Fahrradstellplatz",
-        "address": "",
-        "address_de": "",
-        "address_en": "",
+        "popupContent": "",
+        "popupContent_de": "",
+        "popupContent_en": "",
         "icon": {
           "id": "bikeParkOpIcon"
         }
@@ -2613,9 +2760,9 @@
         "name_en": "Open-air bike park",
         "name_de": "Fahrradstellplatz",
         "name": "Fahrradstellplatz",
-        "address": "Geb\u00fchrenpflichtig:: nein",
-        "address_de": "Geb\u00fchrenpflichtig:: nein",
-        "address_en": "Fee: no",
+        "popupContent": "Geb\u00fchrenpflichtig: nein",
+        "popupContent_de": "Geb\u00fchrenpflichtig: nein",
+        "popupContent_en": "Fee: no",
         "icon": {
           "id": "bikeParkOpIcon"
         }
@@ -2634,9 +2781,9 @@
         "name_en": "Open-air bike park",
         "name_de": "Fahrradstellplatz",
         "name": "Fahrradstellplatz",
-        "address": "Stellpl\u00e4tze: 6",
-        "address_de": "Stellpl\u00e4tze: 6",
-        "address_en": "Capacity: 6",
+        "popupContent": "Stellpl\u00e4tze: 6",
+        "popupContent_de": "Stellpl\u00e4tze: 6",
+        "popupContent_en": "Capacity: 6",
         "icon": {
           "id": "bikeParkOpIcon"
         }
@@ -2655,9 +2802,9 @@
         "name_en": "Open-air bike park",
         "name_de": "Fahrradstellplatz",
         "name": "Fahrradstellplatz",
-        "address": "Stellpl\u00e4tze: 5, Geb\u00fchrenpflichtig:: nein",
-        "address_de": "Stellpl\u00e4tze: 5, Geb\u00fchrenpflichtig:: nein",
-        "address_en": "Capacity: 5, Fee: no",
+        "popupContent": "Stellpl\u00e4tze: 5, Geb\u00fchrenpflichtig: nein",
+        "popupContent_de": "Stellpl\u00e4tze: 5, Geb\u00fchrenpflichtig: nein",
+        "popupContent_en": "Capacity: 5, Fee: no",
         "icon": {
           "id": "bikeParkOpIcon"
         }
@@ -2676,9 +2823,9 @@
         "name_en": "Open-air bike park",
         "name_de": "Fahrradstellplatz",
         "name": "Fahrradstellplatz",
-        "address": "Stellpl\u00e4tze: 3, Geb\u00fchrenpflichtig:: nein",
-        "address_de": "Stellpl\u00e4tze: 3, Geb\u00fchrenpflichtig:: nein",
-        "address_en": "Capacity: 3, Fee: no",
+        "popupContent": "Stellpl\u00e4tze: 3, Geb\u00fchrenpflichtig: nein",
+        "popupContent_de": "Stellpl\u00e4tze: 3, Geb\u00fchrenpflichtig: nein",
+        "popupContent_en": "Capacity: 3, Fee: no",
         "icon": {
           "id": "bikeParkOpIcon"
         }
@@ -2697,9 +2844,9 @@
         "name_en": "Open-air bike park",
         "name_de": "Fahrradstellplatz",
         "name": "Fahrradstellplatz",
-        "address": "Stellpl\u00e4tze: 5, Geb\u00fchrenpflichtig:: nein",
-        "address_de": "Stellpl\u00e4tze: 5, Geb\u00fchrenpflichtig:: nein",
-        "address_en": "Capacity: 5, Fee: no",
+        "popupContent": "Stellpl\u00e4tze: 5, Geb\u00fchrenpflichtig: nein",
+        "popupContent_de": "Stellpl\u00e4tze: 5, Geb\u00fchrenpflichtig: nein",
+        "popupContent_en": "Capacity: 5, Fee: no",
         "icon": {
           "id": "bikeParkOpIcon"
         }
@@ -2718,9 +2865,9 @@
         "name_en": "Open-air bike park",
         "name_de": "Fahrradstellplatz",
         "name": "Fahrradstellplatz",
-        "address": "Stellpl\u00e4tze: 8",
-        "address_de": "Stellpl\u00e4tze: 8",
-        "address_en": "Capacity: 8",
+        "popupContent": "Stellpl\u00e4tze: 8",
+        "popupContent_de": "Stellpl\u00e4tze: 8",
+        "popupContent_en": "Capacity: 8",
         "icon": {
           "id": "bikeParkOpIcon"
         }
@@ -2739,9 +2886,9 @@
         "name_en": "Open-air bike park",
         "name_de": "Fahrradstellplatz",
         "name": "Fahrradstellplatz",
-        "address": "Stellpl\u00e4tze: 6",
-        "address_de": "Stellpl\u00e4tze: 6",
-        "address_en": "Capacity: 6",
+        "popupContent": "Stellpl\u00e4tze: 6",
+        "popupContent_de": "Stellpl\u00e4tze: 6",
+        "popupContent_en": "Capacity: 6",
         "icon": {
           "id": "bikeParkOpIcon"
         }
@@ -2760,9 +2907,9 @@
         "name_en": "Open-air bike park",
         "name_de": "Fahrradstellplatz",
         "name": "Fahrradstellplatz",
-        "address": "Stellpl\u00e4tze: 8",
-        "address_de": "Stellpl\u00e4tze: 8",
-        "address_en": "Capacity: 8",
+        "popupContent": "Stellpl\u00e4tze: 8",
+        "popupContent_de": "Stellpl\u00e4tze: 8",
+        "popupContent_en": "Capacity: 8",
         "icon": {
           "id": "bikeParkOpIcon"
         }
@@ -2781,9 +2928,9 @@
         "name_en": "Open-air bike park",
         "name_de": "Fahrradstellplatz",
         "name": "Fahrradstellplatz",
-        "address": "Stellpl\u00e4tze: 2",
-        "address_de": "Stellpl\u00e4tze: 2",
-        "address_en": "Capacity: 2",
+        "popupContent": "Stellpl\u00e4tze: 2",
+        "popupContent_de": "Stellpl\u00e4tze: 2",
+        "popupContent_en": "Capacity: 2",
         "icon": {
           "id": "bikeParkOpIcon"
         }
@@ -2802,9 +2949,9 @@
         "name_en": "Open-air bike park",
         "name_de": "Fahrradstellplatz",
         "name": "Fahrradstellplatz",
-        "address": "Stellpl\u00e4tze: 6",
-        "address_de": "Stellpl\u00e4tze: 6",
-        "address_en": "Capacity: 6",
+        "popupContent": "Stellpl\u00e4tze: 6",
+        "popupContent_de": "Stellpl\u00e4tze: 6",
+        "popupContent_en": "Capacity: 6",
         "icon": {
           "id": "bikeParkOpIcon"
         }
@@ -2823,9 +2970,9 @@
         "name_en": "Open-air bike park",
         "name_de": "Fahrradstellplatz",
         "name": "Fahrradstellplatz",
-        "address": "Stellpl\u00e4tze: 16",
-        "address_de": "Stellpl\u00e4tze: 16",
-        "address_en": "Capacity: 16",
+        "popupContent": "Stellpl\u00e4tze: 16",
+        "popupContent_de": "Stellpl\u00e4tze: 16",
+        "popupContent_en": "Capacity: 16",
         "icon": {
           "id": "bikeParkOpIcon"
         }
@@ -2844,9 +2991,9 @@
         "name_en": "Open-air bike park",
         "name_de": "Fahrradstellplatz",
         "name": "Fahrradstellplatz",
-        "address": "Stellpl\u00e4tze: 2",
-        "address_de": "Stellpl\u00e4tze: 2",
-        "address_en": "Capacity: 2",
+        "popupContent": "Stellpl\u00e4tze: 2",
+        "popupContent_de": "Stellpl\u00e4tze: 2",
+        "popupContent_en": "Capacity: 2",
         "icon": {
           "id": "bikeParkOpIcon"
         }
@@ -2865,9 +3012,9 @@
         "name_en": "Open-air bike park",
         "name_de": "Fahrradstellplatz",
         "name": "Fahrradstellplatz",
-        "address": "Stellpl\u00e4tze: 2",
-        "address_de": "Stellpl\u00e4tze: 2",
-        "address_en": "Capacity: 2",
+        "popupContent": "Stellpl\u00e4tze: 2",
+        "popupContent_de": "Stellpl\u00e4tze: 2",
+        "popupContent_en": "Capacity: 2",
         "icon": {
           "id": "bikeParkOpIcon"
         }
@@ -2886,9 +3033,9 @@
         "name_en": "Open-air bike park",
         "name_de": "Fahrradstellplatz",
         "name": "Fahrradstellplatz",
-        "address": "Stellpl\u00e4tze: 12",
-        "address_de": "Stellpl\u00e4tze: 12",
-        "address_en": "Capacity: 12",
+        "popupContent": "Stellpl\u00e4tze: 12",
+        "popupContent_de": "Stellpl\u00e4tze: 12",
+        "popupContent_en": "Capacity: 12",
         "icon": {
           "id": "bikeParkOpIcon"
         }
@@ -2907,9 +3054,9 @@
         "name_en": "Open-air bike park",
         "name_de": "Fahrradstellplatz",
         "name": "Fahrradstellplatz",
-        "address": "Stellpl\u00e4tze: 2",
-        "address_de": "Stellpl\u00e4tze: 2",
-        "address_en": "Capacity: 2",
+        "popupContent": "Stellpl\u00e4tze: 2",
+        "popupContent_de": "Stellpl\u00e4tze: 2",
+        "popupContent_en": "Capacity: 2",
         "icon": {
           "id": "bikeParkOpIcon"
         }
@@ -2928,9 +3075,9 @@
         "name_en": "Open-air bike park",
         "name_de": "Fahrradstellplatz",
         "name": "Fahrradstellplatz",
-        "address": "Stellpl\u00e4tze: 2",
-        "address_de": "Stellpl\u00e4tze: 2",
-        "address_en": "Capacity: 2",
+        "popupContent": "Stellpl\u00e4tze: 2",
+        "popupContent_de": "Stellpl\u00e4tze: 2",
+        "popupContent_en": "Capacity: 2",
         "icon": {
           "id": "bikeParkOpIcon"
         }
@@ -2949,9 +3096,9 @@
         "name_en": "Open-air bike park",
         "name_de": "Fahrradstellplatz",
         "name": "Fahrradstellplatz",
-        "address": "Stellpl\u00e4tze: 2",
-        "address_de": "Stellpl\u00e4tze: 2",
-        "address_en": "Capacity: 2",
+        "popupContent": "Stellpl\u00e4tze: 2",
+        "popupContent_de": "Stellpl\u00e4tze: 2",
+        "popupContent_en": "Capacity: 2",
         "icon": {
           "id": "bikeParkOpIcon"
         }
@@ -2970,9 +3117,9 @@
         "name_en": "Open-air bike park",
         "name_de": "Fahrradstellplatz",
         "name": "Fahrradstellplatz",
-        "address": "Stellpl\u00e4tze: 2",
-        "address_de": "Stellpl\u00e4tze: 2",
-        "address_en": "Capacity: 2",
+        "popupContent": "Stellpl\u00e4tze: 2",
+        "popupContent_de": "Stellpl\u00e4tze: 2",
+        "popupContent_en": "Capacity: 2",
         "icon": {
           "id": "bikeParkOpIcon"
         }
@@ -2991,9 +3138,9 @@
         "name_en": "Open-air bike park",
         "name_de": "Fahrradstellplatz",
         "name": "Fahrradstellplatz",
-        "address": "Stellpl\u00e4tze: 2",
-        "address_de": "Stellpl\u00e4tze: 2",
-        "address_en": "Capacity: 2",
+        "popupContent": "Stellpl\u00e4tze: 2",
+        "popupContent_de": "Stellpl\u00e4tze: 2",
+        "popupContent_en": "Capacity: 2",
         "icon": {
           "id": "bikeParkOpIcon"
         }
@@ -3012,9 +3159,9 @@
         "name_en": "Open-air bike park",
         "name_de": "Fahrradstellplatz",
         "name": "Fahrradstellplatz",
-        "address": "Stellpl\u00e4tze: 7",
-        "address_de": "Stellpl\u00e4tze: 7",
-        "address_en": "Capacity: 7",
+        "popupContent": "Stellpl\u00e4tze: 7",
+        "popupContent_de": "Stellpl\u00e4tze: 7",
+        "popupContent_en": "Capacity: 7",
         "icon": {
           "id": "bikeParkOpIcon"
         }
@@ -3033,9 +3180,9 @@
         "name_en": "Open-air bike park",
         "name_de": "Fahrradstellplatz",
         "name": "Fahrradstellplatz",
-        "address": "Stellpl\u00e4tze: 3",
-        "address_de": "Stellpl\u00e4tze: 3",
-        "address_en": "Capacity: 3",
+        "popupContent": "Stellpl\u00e4tze: 3",
+        "popupContent_de": "Stellpl\u00e4tze: 3",
+        "popupContent_en": "Capacity: 3",
         "icon": {
           "id": "bikeParkOpIcon"
         }
@@ -3054,9 +3201,9 @@
         "name_en": "Open-air bike park",
         "name_de": "Fahrradstellplatz",
         "name": "Fahrradstellplatz",
-        "address": "Stellpl\u00e4tze: 12",
-        "address_de": "Stellpl\u00e4tze: 12",
-        "address_en": "Capacity: 12",
+        "popupContent": "Stellpl\u00e4tze: 12",
+        "popupContent_de": "Stellpl\u00e4tze: 12",
+        "popupContent_en": "Capacity: 12",
         "icon": {
           "id": "bikeParkOpIcon"
         }
@@ -3075,9 +3222,9 @@
         "name_en": "Open-air bike park",
         "name_de": "Fahrradstellplatz",
         "name": "Fahrradstellplatz",
-        "address": "Stellpl\u00e4tze: 6",
-        "address_de": "Stellpl\u00e4tze: 6",
-        "address_en": "Capacity: 6",
+        "popupContent": "Stellpl\u00e4tze: 6",
+        "popupContent_de": "Stellpl\u00e4tze: 6",
+        "popupContent_en": "Capacity: 6",
         "icon": {
           "id": "bikeParkOpIcon"
         }
@@ -3096,9 +3243,9 @@
         "name_en": "Open-air bike park",
         "name_de": "Fahrradstellplatz",
         "name": "Fahrradstellplatz",
-        "address": "Stellpl\u00e4tze: 6",
-        "address_de": "Stellpl\u00e4tze: 6",
-        "address_en": "Capacity: 6",
+        "popupContent": "Stellpl\u00e4tze: 6",
+        "popupContent_de": "Stellpl\u00e4tze: 6",
+        "popupContent_en": "Capacity: 6",
         "icon": {
           "id": "bikeParkOpIcon"
         }
@@ -3117,9 +3264,9 @@
         "name_en": "Open-air bike park",
         "name_de": "Fahrradstellplatz",
         "name": "Fahrradstellplatz",
-        "address": "Stellpl\u00e4tze: 10",
-        "address_de": "Stellpl\u00e4tze: 10",
-        "address_en": "Capacity: 10",
+        "popupContent": "Stellpl\u00e4tze: 10",
+        "popupContent_de": "Stellpl\u00e4tze: 10",
+        "popupContent_en": "Capacity: 10",
         "icon": {
           "id": "bikeParkOpIcon"
         }
@@ -3138,9 +3285,9 @@
         "name_en": "Open-air bike park",
         "name_de": "Fahrradstellplatz",
         "name": "Fahrradstellplatz",
-        "address": "Stellpl\u00e4tze: 6",
-        "address_de": "Stellpl\u00e4tze: 6",
-        "address_en": "Capacity: 6",
+        "popupContent": "Stellpl\u00e4tze: 6",
+        "popupContent_de": "Stellpl\u00e4tze: 6",
+        "popupContent_en": "Capacity: 6",
         "icon": {
           "id": "bikeParkOpIcon"
         }
@@ -3159,9 +3306,9 @@
         "name_en": "Open-air bike park",
         "name_de": "Fahrradstellplatz",
         "name": "Fahrradstellplatz",
-        "address": "Stellpl\u00e4tze: 10",
-        "address_de": "Stellpl\u00e4tze: 10",
-        "address_en": "Capacity: 10",
+        "popupContent": "Stellpl\u00e4tze: 10",
+        "popupContent_de": "Stellpl\u00e4tze: 10",
+        "popupContent_en": "Capacity: 10",
         "icon": {
           "id": "bikeParkOpIcon"
         }
@@ -3180,9 +3327,9 @@
         "name_en": "Open-air bike park",
         "name_de": "Fahrradstellplatz",
         "name": "Fahrradstellplatz",
-        "address": "Stellpl\u00e4tze: 26",
-        "address_de": "Stellpl\u00e4tze: 26",
-        "address_en": "Capacity: 26",
+        "popupContent": "Stellpl\u00e4tze: 26",
+        "popupContent_de": "Stellpl\u00e4tze: 26",
+        "popupContent_en": "Capacity: 26",
         "icon": {
           "id": "bikeParkOpIcon"
         }
@@ -3201,9 +3348,9 @@
         "name_en": "Open-air bike park",
         "name_de": "Fahrradstellplatz",
         "name": "Fahrradstellplatz",
-        "address": "Stellpl\u00e4tze: 6",
-        "address_de": "Stellpl\u00e4tze: 6",
-        "address_en": "Capacity: 6",
+        "popupContent": "Stellpl\u00e4tze: 6",
+        "popupContent_de": "Stellpl\u00e4tze: 6",
+        "popupContent_en": "Capacity: 6",
         "icon": {
           "id": "bikeParkOpIcon"
         }
@@ -3222,9 +3369,9 @@
         "name_en": "Open-air bike park",
         "name_de": "Fahrradstellplatz",
         "name": "Fahrradstellplatz",
-        "address": "Stellpl\u00e4tze: 8",
-        "address_de": "Stellpl\u00e4tze: 8",
-        "address_en": "Capacity: 8",
+        "popupContent": "Stellpl\u00e4tze: 8",
+        "popupContent_de": "Stellpl\u00e4tze: 8",
+        "popupContent_en": "Capacity: 8",
         "icon": {
           "id": "bikeParkOpIcon"
         }
@@ -3243,9 +3390,9 @@
         "name_en": "Open-air bike park",
         "name_de": "Fahrradstellplatz",
         "name": "Fahrradstellplatz",
-        "address": "Stellpl\u00e4tze: 16",
-        "address_de": "Stellpl\u00e4tze: 16",
-        "address_en": "Capacity: 16",
+        "popupContent": "Stellpl\u00e4tze: 16",
+        "popupContent_de": "Stellpl\u00e4tze: 16",
+        "popupContent_en": "Capacity: 16",
         "icon": {
           "id": "bikeParkOpIcon"
         }
@@ -3264,9 +3411,9 @@
         "name_en": "Open-air bike park",
         "name_de": "Fahrradstellplatz",
         "name": "Fahrradstellplatz",
-        "address": "Stellpl\u00e4tze: 9",
-        "address_de": "Stellpl\u00e4tze: 9",
-        "address_en": "Capacity: 9",
+        "popupContent": "Stellpl\u00e4tze: 9",
+        "popupContent_de": "Stellpl\u00e4tze: 9",
+        "popupContent_en": "Capacity: 9",
         "icon": {
           "id": "bikeParkOpIcon"
         }
@@ -3285,9 +3432,9 @@
         "name_en": "Open-air bike park",
         "name_de": "Fahrradstellplatz",
         "name": "Fahrradstellplatz",
-        "address": "",
-        "address_de": "",
-        "address_en": "",
+        "popupContent": "",
+        "popupContent_de": "",
+        "popupContent_en": "",
         "icon": {
           "id": "bikeParkOpIcon"
         }
@@ -3306,9 +3453,9 @@
         "name_en": "Open-air bike park",
         "name_de": "Fahrradstellplatz",
         "name": "Fahrradstellplatz",
-        "address": "Stellpl\u00e4tze: 16",
-        "address_de": "Stellpl\u00e4tze: 16",
-        "address_en": "Capacity: 16",
+        "popupContent": "Stellpl\u00e4tze: 16",
+        "popupContent_de": "Stellpl\u00e4tze: 16",
+        "popupContent_en": "Capacity: 16",
         "icon": {
           "id": "bikeParkOpIcon"
         }
@@ -3327,9 +3474,9 @@
         "name_en": "Open-air bike park",
         "name_de": "Fahrradstellplatz",
         "name": "Fahrradstellplatz",
-        "address": "Stellpl\u00e4tze: 10",
-        "address_de": "Stellpl\u00e4tze: 10",
-        "address_en": "Capacity: 10",
+        "popupContent": "Stellpl\u00e4tze: 10",
+        "popupContent_de": "Stellpl\u00e4tze: 10",
+        "popupContent_en": "Capacity: 10",
         "icon": {
           "id": "bikeParkOpIcon"
         }
@@ -3348,9 +3495,9 @@
         "name_en": "Open-air bike park",
         "name_de": "Fahrradstellplatz",
         "name": "Fahrradstellplatz",
-        "address": "",
-        "address_de": "",
-        "address_en": "",
+        "popupContent": "",
+        "popupContent_de": "",
+        "popupContent_en": "",
         "icon": {
           "id": "bikeParkOpIcon"
         }
@@ -3369,9 +3516,9 @@
         "name_en": "Open-air bike park",
         "name_de": "Fahrradstellplatz",
         "name": "Fahrradstellplatz",
-        "address": "Stellpl\u00e4tze: 3",
-        "address_de": "Stellpl\u00e4tze: 3",
-        "address_en": "Capacity: 3",
+        "popupContent": "Stellpl\u00e4tze: 3",
+        "popupContent_de": "Stellpl\u00e4tze: 3",
+        "popupContent_en": "Capacity: 3",
         "icon": {
           "id": "bikeParkOpIcon"
         }
@@ -3390,9 +3537,9 @@
         "name_en": "Open-air bike park",
         "name_de": "Fahrradstellplatz",
         "name": "Fahrradstellplatz",
-        "address": "Stellpl\u00e4tze: 6",
-        "address_de": "Stellpl\u00e4tze: 6",
-        "address_en": "Capacity: 6",
+        "popupContent": "Stellpl\u00e4tze: 6",
+        "popupContent_de": "Stellpl\u00e4tze: 6",
+        "popupContent_en": "Capacity: 6",
         "icon": {
           "id": "bikeParkOpIcon"
         }
@@ -3411,9 +3558,9 @@
         "name_en": "Open-air bike park",
         "name_de": "Fahrradstellplatz",
         "name": "Fahrradstellplatz",
-        "address": "Stellpl\u00e4tze: 6",
-        "address_de": "Stellpl\u00e4tze: 6",
-        "address_en": "Capacity: 6",
+        "popupContent": "Stellpl\u00e4tze: 6",
+        "popupContent_de": "Stellpl\u00e4tze: 6",
+        "popupContent_en": "Capacity: 6",
         "icon": {
           "id": "bikeParkOpIcon"
         }
@@ -3432,9 +3579,9 @@
         "name_en": "Open-air bike park",
         "name_de": "Fahrradstellplatz",
         "name": "Fahrradstellplatz",
-        "address": "Stellpl\u00e4tze: 8",
-        "address_de": "Stellpl\u00e4tze: 8",
-        "address_en": "Capacity: 8",
+        "popupContent": "Stellpl\u00e4tze: 8",
+        "popupContent_de": "Stellpl\u00e4tze: 8",
+        "popupContent_en": "Capacity: 8",
         "icon": {
           "id": "bikeParkOpIcon"
         }
@@ -3453,9 +3600,9 @@
         "name_en": "Open-air bike park",
         "name_de": "Fahrradstellplatz",
         "name": "Fahrradstellplatz",
-        "address": "Stellpl\u00e4tze: 4",
-        "address_de": "Stellpl\u00e4tze: 4",
-        "address_en": "Capacity: 4",
+        "popupContent": "Stellpl\u00e4tze: 4",
+        "popupContent_de": "Stellpl\u00e4tze: 4",
+        "popupContent_en": "Capacity: 4",
         "icon": {
           "id": "bikeParkOpIcon"
         }
@@ -3474,9 +3621,9 @@
         "name_en": "Open-air bike park",
         "name_de": "Fahrradstellplatz",
         "name": "Fahrradstellplatz",
-        "address": "Stellpl\u00e4tze: 8",
-        "address_de": "Stellpl\u00e4tze: 8",
-        "address_en": "Capacity: 8",
+        "popupContent": "Stellpl\u00e4tze: 8",
+        "popupContent_de": "Stellpl\u00e4tze: 8",
+        "popupContent_en": "Capacity: 8",
         "icon": {
           "id": "bikeParkOpIcon"
         }
@@ -3495,9 +3642,9 @@
         "name_en": "Open-air bike park",
         "name_de": "Fahrradstellplatz",
         "name": "Fahrradstellplatz",
-        "address": "Stellpl\u00e4tze: 2",
-        "address_de": "Stellpl\u00e4tze: 2",
-        "address_en": "Capacity: 2",
+        "popupContent": "Stellpl\u00e4tze: 2",
+        "popupContent_de": "Stellpl\u00e4tze: 2",
+        "popupContent_en": "Capacity: 2",
         "icon": {
           "id": "bikeParkOpIcon"
         }
@@ -3516,9 +3663,9 @@
         "name_en": "Open-air bike park",
         "name_de": "Fahrradstellplatz",
         "name": "Fahrradstellplatz",
-        "address": "Stellpl\u00e4tze: 2",
-        "address_de": "Stellpl\u00e4tze: 2",
-        "address_en": "Capacity: 2",
+        "popupContent": "Stellpl\u00e4tze: 2",
+        "popupContent_de": "Stellpl\u00e4tze: 2",
+        "popupContent_en": "Capacity: 2",
         "icon": {
           "id": "bikeParkOpIcon"
         }
@@ -3537,9 +3684,9 @@
         "name_en": "Open-air bike park",
         "name_de": "Fahrradstellplatz",
         "name": "Fahrradstellplatz",
-        "address": "Stellpl\u00e4tze: 4",
-        "address_de": "Stellpl\u00e4tze: 4",
-        "address_en": "Capacity: 4",
+        "popupContent": "Stellpl\u00e4tze: 4",
+        "popupContent_de": "Stellpl\u00e4tze: 4",
+        "popupContent_en": "Capacity: 4",
         "icon": {
           "id": "bikeParkOpIcon"
         }
@@ -3558,9 +3705,9 @@
         "name_en": "Open-air bike park",
         "name_de": "Fahrradstellplatz",
         "name": "Fahrradstellplatz",
-        "address": "Stellpl\u00e4tze: 4",
-        "address_de": "Stellpl\u00e4tze: 4",
-        "address_en": "Capacity: 4",
+        "popupContent": "Stellpl\u00e4tze: 4",
+        "popupContent_de": "Stellpl\u00e4tze: 4",
+        "popupContent_en": "Capacity: 4",
         "icon": {
           "id": "bikeParkOpIcon"
         }
@@ -3579,9 +3726,9 @@
         "name_en": "Open-air bike park",
         "name_de": "Fahrradstellplatz",
         "name": "Fahrradstellplatz",
-        "address": "Stellpl\u00e4tze: 10",
-        "address_de": "Stellpl\u00e4tze: 10",
-        "address_en": "Capacity: 10",
+        "popupContent": "Stellpl\u00e4tze: 10",
+        "popupContent_de": "Stellpl\u00e4tze: 10",
+        "popupContent_en": "Capacity: 10",
         "icon": {
           "id": "bikeParkOpIcon"
         }
@@ -3600,9 +3747,9 @@
         "name_en": "Open-air bike park",
         "name_de": "Fahrradstellplatz",
         "name": "Fahrradstellplatz",
-        "address": "Stellpl\u00e4tze: 12",
-        "address_de": "Stellpl\u00e4tze: 12",
-        "address_en": "Capacity: 12",
+        "popupContent": "Stellpl\u00e4tze: 12",
+        "popupContent_de": "Stellpl\u00e4tze: 12",
+        "popupContent_en": "Capacity: 12",
         "icon": {
           "id": "bikeParkOpIcon"
         }
@@ -3621,9 +3768,9 @@
         "name_en": "Open-air bike park",
         "name_de": "Fahrradstellplatz",
         "name": "Fahrradstellplatz",
-        "address": "Stellpl\u00e4tze: 6",
-        "address_de": "Stellpl\u00e4tze: 6",
-        "address_en": "Capacity: 6",
+        "popupContent": "Stellpl\u00e4tze: 6",
+        "popupContent_de": "Stellpl\u00e4tze: 6",
+        "popupContent_en": "Capacity: 6",
         "icon": {
           "id": "bikeParkOpIcon"
         }
@@ -3642,9 +3789,9 @@
         "name_en": "Open-air bike park",
         "name_de": "Fahrradstellplatz",
         "name": "Fahrradstellplatz",
-        "address": "Stellpl\u00e4tze: 6",
-        "address_de": "Stellpl\u00e4tze: 6",
-        "address_en": "Capacity: 6",
+        "popupContent": "Stellpl\u00e4tze: 6",
+        "popupContent_de": "Stellpl\u00e4tze: 6",
+        "popupContent_en": "Capacity: 6",
         "icon": {
           "id": "bikeParkOpIcon"
         }
@@ -3663,9 +3810,9 @@
         "name_en": "Open-air bike park",
         "name_de": "Fahrradstellplatz",
         "name": "Fahrradstellplatz",
-        "address": "Stellpl\u00e4tze: 3",
-        "address_de": "Stellpl\u00e4tze: 3",
-        "address_en": "Capacity: 3",
+        "popupContent": "Stellpl\u00e4tze: 3",
+        "popupContent_de": "Stellpl\u00e4tze: 3",
+        "popupContent_en": "Capacity: 3",
         "icon": {
           "id": "bikeParkOpIcon"
         }
@@ -3684,9 +3831,9 @@
         "name_en": "Open-air bike park",
         "name_de": "Fahrradstellplatz",
         "name": "Fahrradstellplatz",
-        "address": "Stellpl\u00e4tze: 4",
-        "address_de": "Stellpl\u00e4tze: 4",
-        "address_en": "Capacity: 4",
+        "popupContent": "Stellpl\u00e4tze: 4",
+        "popupContent_de": "Stellpl\u00e4tze: 4",
+        "popupContent_en": "Capacity: 4",
         "icon": {
           "id": "bikeParkOpIcon"
         }
@@ -3705,9 +3852,9 @@
         "name_en": "Open-air bike park",
         "name_de": "Fahrradstellplatz",
         "name": "Fahrradstellplatz",
-        "address": "Stellpl\u00e4tze: 4",
-        "address_de": "Stellpl\u00e4tze: 4",
-        "address_en": "Capacity: 4",
+        "popupContent": "Stellpl\u00e4tze: 4",
+        "popupContent_de": "Stellpl\u00e4tze: 4",
+        "popupContent_en": "Capacity: 4",
         "icon": {
           "id": "bikeParkOpIcon"
         }
@@ -3726,9 +3873,9 @@
         "name_en": "Open-air bike park",
         "name_de": "Fahrradstellplatz",
         "name": "Fahrradstellplatz",
-        "address": "Stellpl\u00e4tze: 4",
-        "address_de": "Stellpl\u00e4tze: 4",
-        "address_en": "Capacity: 4",
+        "popupContent": "Stellpl\u00e4tze: 4",
+        "popupContent_de": "Stellpl\u00e4tze: 4",
+        "popupContent_en": "Capacity: 4",
         "icon": {
           "id": "bikeParkOpIcon"
         }
@@ -3747,9 +3894,9 @@
         "name_en": "Open-air bike park",
         "name_de": "Fahrradstellplatz",
         "name": "Fahrradstellplatz",
-        "address": "Stellpl\u00e4tze: 8",
-        "address_de": "Stellpl\u00e4tze: 8",
-        "address_en": "Capacity: 8",
+        "popupContent": "Stellpl\u00e4tze: 8",
+        "popupContent_de": "Stellpl\u00e4tze: 8",
+        "popupContent_en": "Capacity: 8",
         "icon": {
           "id": "bikeParkOpIcon"
         }
@@ -3768,9 +3915,9 @@
         "name_en": "Open-air bike park",
         "name_de": "Fahrradstellplatz",
         "name": "Fahrradstellplatz",
-        "address": "Stellpl\u00e4tze: 6",
-        "address_de": "Stellpl\u00e4tze: 6",
-        "address_en": "Capacity: 6",
+        "popupContent": "Stellpl\u00e4tze: 6",
+        "popupContent_de": "Stellpl\u00e4tze: 6",
+        "popupContent_en": "Capacity: 6",
         "icon": {
           "id": "bikeParkOpIcon"
         }
@@ -3789,9 +3936,9 @@
         "name_en": "Open-air bike park",
         "name_de": "Fahrradstellplatz",
         "name": "Fahrradstellplatz",
-        "address": "Stellpl\u00e4tze: 6",
-        "address_de": "Stellpl\u00e4tze: 6",
-        "address_en": "Capacity: 6",
+        "popupContent": "Stellpl\u00e4tze: 6",
+        "popupContent_de": "Stellpl\u00e4tze: 6",
+        "popupContent_en": "Capacity: 6",
         "icon": {
           "id": "bikeParkOpIcon"
         }
@@ -3810,9 +3957,9 @@
         "name_en": "Open-air bike park",
         "name_de": "Fahrradstellplatz",
         "name": "Fahrradstellplatz",
-        "address": "Stellpl\u00e4tze: 2",
-        "address_de": "Stellpl\u00e4tze: 2",
-        "address_en": "Capacity: 2",
+        "popupContent": "Stellpl\u00e4tze: 2",
+        "popupContent_de": "Stellpl\u00e4tze: 2",
+        "popupContent_en": "Capacity: 2",
         "icon": {
           "id": "bikeParkOpIcon"
         }
@@ -3831,9 +3978,9 @@
         "name_en": "Open-air bike park",
         "name_de": "Fahrradstellplatz",
         "name": "Fahrradstellplatz",
-        "address": "Stellpl\u00e4tze: 7",
-        "address_de": "Stellpl\u00e4tze: 7",
-        "address_en": "Capacity: 7",
+        "popupContent": "Stellpl\u00e4tze: 7",
+        "popupContent_de": "Stellpl\u00e4tze: 7",
+        "popupContent_en": "Capacity: 7",
         "icon": {
           "id": "bikeParkOpIcon"
         }
@@ -3852,9 +3999,9 @@
         "name_en": "Open-air bike park",
         "name_de": "Fahrradstellplatz",
         "name": "Fahrradstellplatz",
-        "address": "Stellpl\u00e4tze: 7",
-        "address_de": "Stellpl\u00e4tze: 7",
-        "address_en": "Capacity: 7",
+        "popupContent": "Stellpl\u00e4tze: 7",
+        "popupContent_de": "Stellpl\u00e4tze: 7",
+        "popupContent_en": "Capacity: 7",
         "icon": {
           "id": "bikeParkOpIcon"
         }
@@ -3873,9 +4020,9 @@
         "name_en": "Open-air bike park",
         "name_de": "Fahrradstellplatz",
         "name": "Fahrradstellplatz",
-        "address": "Stellpl\u00e4tze: 4",
-        "address_de": "Stellpl\u00e4tze: 4",
-        "address_en": "Capacity: 4",
+        "popupContent": "Stellpl\u00e4tze: 4",
+        "popupContent_de": "Stellpl\u00e4tze: 4",
+        "popupContent_en": "Capacity: 4",
         "icon": {
           "id": "bikeParkOpIcon"
         }
@@ -3894,9 +4041,9 @@
         "name_en": "Open-air bike park",
         "name_de": "Fahrradstellplatz",
         "name": "Fahrradstellplatz",
-        "address": "Stellpl\u00e4tze: 3",
-        "address_de": "Stellpl\u00e4tze: 3",
-        "address_en": "Capacity: 3",
+        "popupContent": "Stellpl\u00e4tze: 3",
+        "popupContent_de": "Stellpl\u00e4tze: 3",
+        "popupContent_en": "Capacity: 3",
         "icon": {
           "id": "bikeParkOpIcon"
         }
@@ -3915,9 +4062,9 @@
         "name_en": "Open-air bike park",
         "name_de": "Fahrradstellplatz",
         "name": "Fahrradstellplatz",
-        "address": "Stellpl\u00e4tze: 2",
-        "address_de": "Stellpl\u00e4tze: 2",
-        "address_en": "Capacity: 2",
+        "popupContent": "Stellpl\u00e4tze: 2",
+        "popupContent_de": "Stellpl\u00e4tze: 2",
+        "popupContent_en": "Capacity: 2",
         "icon": {
           "id": "bikeParkOpIcon"
         }
@@ -3936,9 +4083,9 @@
         "name_en": "Open-air bike park",
         "name_de": "Fahrradstellplatz",
         "name": "Fahrradstellplatz",
-        "address": "Stellpl\u00e4tze: 5",
-        "address_de": "Stellpl\u00e4tze: 5",
-        "address_en": "Capacity: 5",
+        "popupContent": "Stellpl\u00e4tze: 5",
+        "popupContent_de": "Stellpl\u00e4tze: 5",
+        "popupContent_en": "Capacity: 5",
         "icon": {
           "id": "bikeParkOpIcon"
         }
@@ -3957,9 +4104,9 @@
         "name_en": "Open-air bike park",
         "name_de": "Fahrradstellplatz",
         "name": "Fahrradstellplatz",
-        "address": "Stellpl\u00e4tze: 6",
-        "address_de": "Stellpl\u00e4tze: 6",
-        "address_en": "Capacity: 6",
+        "popupContent": "Stellpl\u00e4tze: 6",
+        "popupContent_de": "Stellpl\u00e4tze: 6",
+        "popupContent_en": "Capacity: 6",
         "icon": {
           "id": "bikeParkOpIcon"
         }
@@ -3978,9 +4125,9 @@
         "name_en": "Open-air bike park",
         "name_de": "Fahrradstellplatz",
         "name": "Fahrradstellplatz",
-        "address": "Stellpl\u00e4tze: 7",
-        "address_de": "Stellpl\u00e4tze: 7",
-        "address_en": "Capacity: 7",
+        "popupContent": "Stellpl\u00e4tze: 7",
+        "popupContent_de": "Stellpl\u00e4tze: 7",
+        "popupContent_en": "Capacity: 7",
         "icon": {
           "id": "bikeParkOpIcon"
         }
@@ -3999,9 +4146,9 @@
         "name_en": "Open-air bike park",
         "name_de": "Fahrradstellplatz",
         "name": "Fahrradstellplatz",
-        "address": "Stellpl\u00e4tze: 8",
-        "address_de": "Stellpl\u00e4tze: 8",
-        "address_en": "Capacity: 8",
+        "popupContent": "Stellpl\u00e4tze: 8",
+        "popupContent_de": "Stellpl\u00e4tze: 8",
+        "popupContent_en": "Capacity: 8",
         "icon": {
           "id": "bikeParkOpIcon"
         }
@@ -4020,9 +4167,9 @@
         "name_en": "Open-air bike park",
         "name_de": "Fahrradstellplatz",
         "name": "Fahrradstellplatz",
-        "address": "Stellpl\u00e4tze: 5",
-        "address_de": "Stellpl\u00e4tze: 5",
-        "address_en": "Capacity: 5",
+        "popupContent": "Stellpl\u00e4tze: 5",
+        "popupContent_de": "Stellpl\u00e4tze: 5",
+        "popupContent_en": "Capacity: 5",
         "icon": {
           "id": "bikeParkOpIcon"
         }
@@ -4041,9 +4188,9 @@
         "name_en": "Open-air bike park",
         "name_de": "Fahrradstellplatz",
         "name": "Fahrradstellplatz",
-        "address": "Stellpl\u00e4tze: 8",
-        "address_de": "Stellpl\u00e4tze: 8",
-        "address_en": "Capacity: 8",
+        "popupContent": "Stellpl\u00e4tze: 8",
+        "popupContent_de": "Stellpl\u00e4tze: 8",
+        "popupContent_en": "Capacity: 8",
         "icon": {
           "id": "bikeParkOpIcon"
         }
@@ -4062,9 +4209,9 @@
         "name_en": "Open-air bike park",
         "name_de": "Fahrradstellplatz",
         "name": "Fahrradstellplatz",
-        "address": "Stellpl\u00e4tze: 5",
-        "address_de": "Stellpl\u00e4tze: 5",
-        "address_en": "Capacity: 5",
+        "popupContent": "Stellpl\u00e4tze: 5",
+        "popupContent_de": "Stellpl\u00e4tze: 5",
+        "popupContent_en": "Capacity: 5",
         "icon": {
           "id": "bikeParkOpIcon"
         }
@@ -4083,9 +4230,9 @@
         "name_en": "Open-air bike park",
         "name_de": "Fahrradstellplatz",
         "name": "Fahrradstellplatz",
-        "address": "Stellpl\u00e4tze: 6",
-        "address_de": "Stellpl\u00e4tze: 6",
-        "address_en": "Capacity: 6",
+        "popupContent": "Stellpl\u00e4tze: 6",
+        "popupContent_de": "Stellpl\u00e4tze: 6",
+        "popupContent_en": "Capacity: 6",
         "icon": {
           "id": "bikeParkOpIcon"
         }
@@ -4104,9 +4251,9 @@
         "name_en": "Open-air bike park",
         "name_de": "Fahrradstellplatz",
         "name": "Fahrradstellplatz",
-        "address": "",
-        "address_de": "",
-        "address_en": "",
+        "popupContent": "",
+        "popupContent_de": "",
+        "popupContent_en": "",
         "icon": {
           "id": "bikeParkOpIcon"
         }
@@ -4125,9 +4272,9 @@
         "name_en": "Open-air bike park",
         "name_de": "Fahrradstellplatz",
         "name": "Fahrradstellplatz",
-        "address": "Stellpl\u00e4tze: 25",
-        "address_de": "Stellpl\u00e4tze: 25",
-        "address_en": "Capacity: 25",
+        "popupContent": "Stellpl\u00e4tze: 25",
+        "popupContent_de": "Stellpl\u00e4tze: 25",
+        "popupContent_en": "Capacity: 25",
         "icon": {
           "id": "bikeParkOpIcon"
         }
@@ -4146,9 +4293,9 @@
         "name_en": "Open-air bike park",
         "name_de": "Fahrradstellplatz",
         "name": "Fahrradstellplatz",
-        "address": "Stellpl\u00e4tze: 12",
-        "address_de": "Stellpl\u00e4tze: 12",
-        "address_en": "Capacity: 12",
+        "popupContent": "Stellpl\u00e4tze: 12",
+        "popupContent_de": "Stellpl\u00e4tze: 12",
+        "popupContent_en": "Capacity: 12",
         "icon": {
           "id": "bikeParkOpIcon"
         }
@@ -4167,9 +4314,9 @@
         "name_en": "Open-air bike park",
         "name_de": "Fahrradstellplatz",
         "name": "Fahrradstellplatz",
-        "address": "Stellpl\u00e4tze: 20",
-        "address_de": "Stellpl\u00e4tze: 20",
-        "address_en": "Capacity: 20",
+        "popupContent": "Stellpl\u00e4tze: 20",
+        "popupContent_de": "Stellpl\u00e4tze: 20",
+        "popupContent_en": "Capacity: 20",
         "icon": {
           "id": "bikeParkOpIcon"
         }
@@ -4188,9 +4335,9 @@
         "name_en": "Open-air bike park",
         "name_de": "Fahrradstellplatz",
         "name": "Fahrradstellplatz",
-        "address": "Stellpl\u00e4tze: 10",
-        "address_de": "Stellpl\u00e4tze: 10",
-        "address_en": "Capacity: 10",
+        "popupContent": "Stellpl\u00e4tze: 10",
+        "popupContent_de": "Stellpl\u00e4tze: 10",
+        "popupContent_en": "Capacity: 10",
         "icon": {
           "id": "bikeParkOpIcon"
         }
@@ -4200,6 +4347,300 @@
         "coordinates": [
           9.0280634,
           48.7028077
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "name_en": "Open-air bike park",
+        "name_de": "Fahrradstellplatz",
+        "name": "Fahrradstellplatz",
+        "popupContent": "Stellpl\u00e4tze: 6",
+        "popupContent_de": "Stellpl\u00e4tze: 6",
+        "popupContent_en": "Capacity: 6",
+        "icon": {
+          "id": "bikeParkOpIcon"
+        }
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          9.0248222,
+          48.7016088
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "name_en": "Open-air bike park",
+        "name_de": "Fahrradstellplatz",
+        "name": "Fahrradstellplatz",
+        "popupContent": "Stellpl\u00e4tze: 6",
+        "popupContent_de": "Stellpl\u00e4tze: 6",
+        "popupContent_en": "Capacity: 6",
+        "icon": {
+          "id": "bikeParkOpIcon"
+        }
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          9.0062083,
+          48.6808601
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "name_en": "Open-air bike park",
+        "name_de": "Fahrradstellplatz",
+        "name": "Fahrradstellplatz",
+        "popupContent": "Stellpl\u00e4tze: 1",
+        "popupContent_de": "Stellpl\u00e4tze: 1",
+        "popupContent_en": "Capacity: 1",
+        "icon": {
+          "id": "bikeParkOpIcon"
+        }
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          8.8939235,
+          48.6235447
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "name_en": "Open-air bike park",
+        "name_de": "Fahrradstellplatz",
+        "name": "Fahrradstellplatz",
+        "popupContent": "Stellpl\u00e4tze: 6",
+        "popupContent_de": "Stellpl\u00e4tze: 6",
+        "popupContent_en": "Capacity: 6",
+        "icon": {
+          "id": "bikeParkOpIcon"
+        }
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          8.8926749,
+          48.6232371
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "name_en": "Open-air bike park",
+        "name_de": "Fahrradstellplatz",
+        "name": "Fahrradstellplatz",
+        "popupContent": "Stellpl\u00e4tze: 8",
+        "popupContent_de": "Stellpl\u00e4tze: 8",
+        "popupContent_en": "Capacity: 8",
+        "icon": {
+          "id": "bikeParkOpIcon"
+        }
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          8.8926387,
+          48.62316
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "name_en": "Open-air bike park",
+        "name_de": "Fahrradstellplatz",
+        "name": "Fahrradstellplatz",
+        "popupContent": "Stellpl\u00e4tze: 4",
+        "popupContent_de": "Stellpl\u00e4tze: 4",
+        "popupContent_en": "Capacity: 4",
+        "icon": {
+          "id": "bikeParkOpIcon"
+        }
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          8.8928559,
+          48.623199
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "name_en": "Open-air bike park",
+        "name_de": "Fahrradstellplatz",
+        "name": "Fahrradstellplatz",
+        "popupContent": "Stellpl\u00e4tze: 4",
+        "popupContent_de": "Stellpl\u00e4tze: 4",
+        "popupContent_en": "Capacity: 4",
+        "icon": {
+          "id": "bikeParkOpIcon"
+        }
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          8.8924697,
+          48.6231104
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "name_en": "Open-air bike park",
+        "name_de": "Fahrradstellplatz",
+        "name": "Fahrradstellplatz",
+        "popupContent": "Stellpl\u00e4tze: 2",
+        "popupContent_de": "Stellpl\u00e4tze: 2",
+        "popupContent_en": "Capacity: 2",
+        "icon": {
+          "id": "bikeParkOpIcon"
+        }
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          8.892066,
+          48.6231219
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "name_en": "Open-air bike park",
+        "name_de": "Fahrradstellplatz",
+        "name": "Fahrradstellplatz",
+        "popupContent": "Stellpl\u00e4tze: 2",
+        "popupContent_de": "Stellpl\u00e4tze: 2",
+        "popupContent_en": "Capacity: 2",
+        "icon": {
+          "id": "bikeParkOpIcon"
+        }
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          8.8917817,
+          48.6230971
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "name_en": "Open-air bike park",
+        "name_de": "Fahrradstellplatz",
+        "name": "Fahrradstellplatz",
+        "popupContent": "Stellpl\u00e4tze: 2",
+        "popupContent_de": "Stellpl\u00e4tze: 2",
+        "popupContent_en": "Capacity: 2",
+        "icon": {
+          "id": "bikeParkOpIcon"
+        }
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          8.8901959,
+          48.6230368
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "name_en": "Open-air bike park",
+        "name_de": "Fahrradstellplatz",
+        "name": "Fahrradstellplatz",
+        "popupContent": "Stellpl\u00e4tze: 8",
+        "popupContent_de": "Stellpl\u00e4tze: 8",
+        "popupContent_en": "Capacity: 8",
+        "icon": {
+          "id": "bikeParkOpIcon"
+        }
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          8.8974557,
+          48.6372103
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "name_en": "Open-air bike park",
+        "name_de": "Fahrradstellplatz",
+        "name": "Fahrradstellplatz",
+        "popupContent": "Stellpl\u00e4tze: 3",
+        "popupContent_de": "Stellpl\u00e4tze: 3",
+        "popupContent_en": "Capacity: 3",
+        "icon": {
+          "id": "bikeParkOpIcon"
+        }
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          8.9036299,
+          48.6417557
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "name_en": "Open-air bike park",
+        "name_de": "Fahrradstellplatz",
+        "name": "Fahrradstellplatz",
+        "popupContent": "Stellpl\u00e4tze: 14",
+        "popupContent_de": "Stellpl\u00e4tze: 14",
+        "popupContent_en": "Capacity: 14",
+        "icon": {
+          "id": "bikeParkOpIcon"
+        }
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          8.8697299,
+          48.5985604
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "name_en": "Open-air bike park",
+        "name_de": "Fahrradstellplatz",
+        "name": "Fahrradstellplatz",
+        "popupContent": "Stellpl\u00e4tze: 26",
+        "popupContent_de": "Stellpl\u00e4tze: 26",
+        "popupContent_en": "Capacity: 26",
+        "icon": {
+          "id": "bikeParkOpIcon"
+        }
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          8.8700397,
+          48.5983865
         ]
       }
     }

--- a/static/assets/geojson/hb-layers/bicycleinfrastructure.geojson
+++ b/static/assets/geojson/hb-layers/bicycleinfrastructure.geojson
@@ -7,12 +7,12 @@
         "name_en": "Bicycle repair station",
         "name_de": "Fahrradreparaturstation",
         "name": "Fahrradreparaturstation",
-        "address": "\u00d6ffnungszeiten: 24/7",
-        "address_de": "\u00d6ffnungszeiten: 24/7",
-        "address_en": "Opening hours: 24/7",
+        "popupContent": "\u00d6ffnungszeiten: 24/7",
+        "popupContent_de": "\u00d6ffnungszeiten: 24/7",
+        "popupContent_en": "Opening hours: 24/7",
         "icon": {
           "id": "bikeRepIcon",
-          "svg": "<svg xmlns=\"http://www.w3.org/2000/svg\" id=\"Ebene_1\" data-name=\"Ebene 1\" viewBox=\"0 0 32.53 32.54\">\n  <defs>\n    <style>\n      .cls-2{fill:#fff}\n    </style>\n  </defs>\n  <path fill=\"#000001\" d=\"M313.29 384.05A16.27 16.27 0 11297 367.78a16.27 16.27 0 0116.26 16.27\" transform=\"translate(-280.76 -367.78)\"/>\n  <path d=\"M299.66 384.6a1.43 1.43 0 01-1.05-.44 1.35 1.35 0 01-.46-1 1.56 1.56 0 011.51-1.51 1.42 1.42 0 011 .45 1.51 1.51 0 01.44 1.06 1.5 1.5 0 01-1.48 1.47zm-7.87 4.89a3.55 3.55 0 012.65 1.09 3.62 3.62 0 011.07 2.67 3.66 3.66 0 01-3.72 3.72 3.65 3.65 0 01-2.67-1.07 3.55 3.55 0 01-1.09-2.65 3.72 3.72 0 013.76-3.76zm0 6.36a2.59 2.59 0 002.6-2.6 2.53 2.53 0 00-.76-1.86 2.45 2.45 0 00-1.84-.78 2.66 2.66 0 00-2.64 2.64 2.46 2.46 0 00.78 1.84 2.53 2.53 0 001.86.76zm4.32-7.49l1.65 1.73v4.63h-1.47V391l-2.43-2.11a1.18 1.18 0 01-.42-1.05 1.45 1.45 0 01.42-1.06l2.11-2.11a1.19 1.19 0 011.06-.42 1.86 1.86 0 011.19.42l1.44 1.45a3.68 3.68 0 002.67 1.12v1.51a5.18 5.18 0 01-3.79-1.58l-.6-.6zm6.15 1.13a3.72 3.72 0 013.76 3.76 3.55 3.55 0 01-1.09 2.65 3.62 3.62 0 01-2.67 1.07 3.66 3.66 0 01-3.72-3.72 3.62 3.62 0 011.07-2.67 3.55 3.55 0 012.65-1.09zm0 6.36a2.53 2.53 0 001.86-.76 2.46 2.46 0 00.78-1.84 2.66 2.66 0 00-2.64-2.64 2.46 2.46 0 00-1.84.78 2.53 2.53 0 00-.76 1.86 2.59 2.59 0 002.6 2.6zM304 374.92a.38.38 0 01.38.14.65.65 0 01.15.48v1.86a.51.51 0 01-.57.58h-7.4a3.46 3.46 0 01-1.34 1.58 3.67 3.67 0 01-2.07.61 3.79 3.79 0 01-2.22-.69 3.33 3.33 0 01-1.33-1.79h3.55v-2.44h-3.55a3.8 3.8 0 013.54-2.48 3.76 3.76 0 012.08.61 3.46 3.46 0 011.34 1.58z\" class=\"cls-2\" transform=\"translate(-280.76 -367.78)\"/>\n</svg>"
+          "svg": "<svg xmlns=\"http://www.w3.org/2000/svg\" id=\"Ebene_1\" data-name=\"Ebene 1\" viewBox=\"0 0 32.53 32.54\">  <defs>    <style>      .cls-2{fill:#fff}    </style>  </defs>  <path fill=\"#000001\" d=\"M313.29 384.05A16.27 16.27 0 11297 367.78a16.27 16.27 0 0116.26 16.27\" transform=\"translate(-280.76 -367.78)\"/>  <path d=\"M299.66 384.6a1.43 1.43 0 01-1.05-.44 1.35 1.35 0 01-.46-1 1.56 1.56 0 011.51-1.51 1.42 1.42 0 011 .45 1.51 1.51 0 01.44 1.06 1.5 1.5 0 01-1.48 1.47zm-7.87 4.89a3.55 3.55 0 012.65 1.09 3.62 3.62 0 011.07 2.67 3.66 3.66 0 01-3.72 3.72 3.65 3.65 0 01-2.67-1.07 3.55 3.55 0 01-1.09-2.65 3.72 3.72 0 013.76-3.76zm0 6.36a2.59 2.59 0 002.6-2.6 2.53 2.53 0 00-.76-1.86 2.45 2.45 0 00-1.84-.78 2.66 2.66 0 00-2.64 2.64 2.46 2.46 0 00.78 1.84 2.53 2.53 0 001.86.76zm4.32-7.49l1.65 1.73v4.63h-1.47V391l-2.43-2.11a1.18 1.18 0 01-.42-1.05 1.45 1.45 0 01.42-1.06l2.11-2.11a1.19 1.19 0 011.06-.42 1.86 1.86 0 011.19.42l1.44 1.45a3.68 3.68 0 002.67 1.12v1.51a5.18 5.18 0 01-3.79-1.58l-.6-.6zm6.15 1.13a3.72 3.72 0 013.76 3.76 3.55 3.55 0 01-1.09 2.65 3.62 3.62 0 01-2.67 1.07 3.66 3.66 0 01-3.72-3.72 3.62 3.62 0 011.07-2.67 3.55 3.55 0 012.65-1.09zm0 6.36a2.53 2.53 0 001.86-.76 2.46 2.46 0 00.78-1.84 2.66 2.66 0 00-2.64-2.64 2.46 2.46 0 00-1.84.78 2.53 2.53 0 00-.76 1.86 2.59 2.59 0 002.6 2.6zM304 374.92a.38.38 0 01.38.14.65.65 0 01.15.48v1.86a.51.51 0 01-.57.58h-7.4a3.46 3.46 0 01-1.34 1.58 3.67 3.67 0 01-2.07.61 3.79 3.79 0 01-2.22-.69 3.33 3.33 0 01-1.33-1.79h3.55v-2.44h-3.55a3.8 3.8 0 013.54-2.48 3.76 3.76 0 012.08.61 3.46 3.46 0 011.34 1.58z\" class=\"cls-2\" transform=\"translate(-280.76 -367.78)\"/></svg>"
         }
       },
       "geometry": {
@@ -29,9 +29,9 @@
         "name_en": "Bicycle repair station",
         "name_de": "Fahrradreparaturstation",
         "name": "Fahrradreparaturstation",
-        "address": "\u00d6ffnungszeiten: 24/7",
-        "address_de": "\u00d6ffnungszeiten: 24/7",
-        "address_en": "Opening hours: 24/7",
+        "popupContent": "\u00d6ffnungszeiten: 24/7",
+        "popupContent_de": "\u00d6ffnungszeiten: 24/7",
+        "popupContent_en": "Opening hours: 24/7",
         "icon": {
           "id": "bikeRepIcon"
         }
@@ -50,9 +50,9 @@
         "name_en": "Bicycle repair station",
         "name_de": "Fahrradreparaturstation",
         "name": "Fahrradreparaturstation",
-        "address": "\u00d6ffnungszeiten: 24/7",
-        "address_de": "\u00d6ffnungszeiten: 24/7",
-        "address_en": "Opening hours: 24/7",
+        "popupContent": "\u00d6ffnungszeiten: 24/7",
+        "popupContent_de": "\u00d6ffnungszeiten: 24/7",
+        "popupContent_en": "Opening hours: 24/7",
         "icon": {
           "id": "bikeRepIcon"
         }
@@ -71,9 +71,9 @@
         "name_en": "Bicycle repair station",
         "name_de": "Fahrradreparaturstation",
         "name": "Fahrradreparaturstation",
-        "address": "\u00d6ffnungszeiten: 24/7",
-        "address_de": "\u00d6ffnungszeiten: 24/7",
-        "address_en": "Opening hours: 24/7",
+        "popupContent": "\u00d6ffnungszeiten: 24/7",
+        "popupContent_de": "\u00d6ffnungszeiten: 24/7",
+        "popupContent_en": "Opening hours: 24/7",
         "icon": {
           "id": "bikeRepIcon"
         }
@@ -92,9 +92,9 @@
         "name_en": "Bicycle repair station",
         "name_de": "Fahrradreparaturstation",
         "name": "Fahrradreparaturstation",
-        "address": "\u00d6ffnungszeiten: 24/7",
-        "address_de": "\u00d6ffnungszeiten: 24/7",
-        "address_en": "Opening hours: 24/7",
+        "popupContent": "\u00d6ffnungszeiten: 24/7",
+        "popupContent_de": "\u00d6ffnungszeiten: 24/7",
+        "popupContent_en": "Opening hours: 24/7",
         "icon": {
           "id": "bikeRepIcon"
         }
@@ -113,9 +113,9 @@
         "name_en": "Bicycle repair station",
         "name_de": "Fahrradreparaturstation",
         "name": "Fahrradreparaturstation",
-        "address": "\u00d6ffnungszeiten: 24/7",
-        "address_de": "\u00d6ffnungszeiten: 24/7",
-        "address_en": "Opening hours: 24/7",
+        "popupContent": "\u00d6ffnungszeiten: 24/7",
+        "popupContent_de": "\u00d6ffnungszeiten: 24/7",
+        "popupContent_en": "Opening hours: 24/7",
         "icon": {
           "id": "bikeRepIcon"
         }
@@ -134,9 +134,9 @@
         "name_en": "Bicycle repair station",
         "name_de": "Fahrradreparaturstation",
         "name": "Fahrradreparaturstation",
-        "address": "\u00d6ffnungszeiten: 24/7",
-        "address_de": "\u00d6ffnungszeiten: 24/7",
-        "address_en": "Opening hours: 24/7",
+        "popupContent": "\u00d6ffnungszeiten: 24/7",
+        "popupContent_de": "\u00d6ffnungszeiten: 24/7",
+        "popupContent_en": "Opening hours: 24/7",
         "icon": {
           "id": "bikeRepIcon"
         }
@@ -155,9 +155,9 @@
         "name_en": "Bicycle repair station",
         "name_de": "Fahrradreparaturstation",
         "name": "Fahrradreparaturstation",
-        "address": "\u00d6ffnungszeiten: 24/7",
-        "address_de": "\u00d6ffnungszeiten: 24/7",
-        "address_en": "Opening hours: 24/7",
+        "popupContent": "\u00d6ffnungszeiten: 24/7",
+        "popupContent_de": "\u00d6ffnungszeiten: 24/7",
+        "popupContent_en": "Opening hours: 24/7",
         "icon": {
           "id": "bikeRepIcon"
         }
@@ -176,9 +176,9 @@
         "name_en": "Bicycle repair station",
         "name_de": "Fahrradreparaturstation",
         "name": "Fahrradreparaturstation",
-        "address": "\u00d6ffnungszeiten: 24/7",
-        "address_de": "\u00d6ffnungszeiten: 24/7",
-        "address_en": "Opening hours: 24/7",
+        "popupContent": "\u00d6ffnungszeiten: 24/7",
+        "popupContent_de": "\u00d6ffnungszeiten: 24/7",
+        "popupContent_en": "Opening hours: 24/7",
         "icon": {
           "id": "bikeRepIcon"
         }
@@ -197,9 +197,9 @@
         "name_en": "Bicycle repair station",
         "name_de": "Fahrradreparaturstation",
         "name": "Fahrradreparaturstation",
-        "address": "Geb\u00fchrenpflichtig:: nein, \u00d6ffnungszeiten: 24/7",
-        "address_de": "Geb\u00fchrenpflichtig:: nein, \u00d6ffnungszeiten: 24/7",
-        "address_en": "Fee: no, Opening hours: 24/7",
+        "popupContent": "Geb\u00fchrenpflichtig: nein, \u00d6ffnungszeiten: 24/7",
+        "popupContent_de": "Geb\u00fchrenpflichtig: nein, \u00d6ffnungszeiten: 24/7",
+        "popupContent_en": "Fee: no, Opening hours: 24/7",
         "icon": {
           "id": "bikeRepIcon"
         }
@@ -218,12 +218,12 @@
         "name": "Fahrrad Kaiser",
         "name_en": "Fahrrad Kaiser",
         "name_de": "Fahrrad Kaiser",
-        "address": "\u00d6ffnungszeiten: Mo-Fr 10:00-19:00; So 09:00-16:00;Telefon: +49 7031 43589 0, Barrierefrei: begrenzt",
-        "address_de": "\u00d6ffnungszeiten: Mo-Fr 10:00-19:00; So 09:00-16:00;Telefon: +49 7031 43589 0, Barrierefrei: begrenzt",
-        "address_en": "Opening hours: Mo-Fr 10:00-19:00; Sa 09:00-16:00;Phone: +49 7031 43589 0, Wheelchair: limited",
+        "popupContent": "\u00d6ffnungszeiten: Mo-Fr 10:00-19:00; So 09:00-16:00;Telefon: +49 7031 43589 0, Barrierefrei: begrenzt",
+        "popupContent_de": "\u00d6ffnungszeiten: Mo-Fr 10:00-19:00; So 09:00-16:00;Telefon: +49 7031 43589 0, Barrierefrei: begrenzt",
+        "popupContent_en": "Opening hours: Mo-Fr 10:00-19:00; Sa 09:00-16:00;Phone: +49 7031 43589 0, Wheelchair: limited",
         "icon": {
           "id": "bikeShopIcon",
-          "svg": "<svg xmlns=\"http://www.w3.org/2000/svg\" data-name=\"Ebene 1\" viewBox=\"0 0 32.53 32.53\">\n  <path fill=\"#000001\" d=\"M32.53 16.27A16.27 16.27 0 1116.24 0 16.26 16.26 0 0132.5 16.27\"/>\n  <text fill=\"#fff\" font-family=\"Interstate-Bold\" font-size=\"7.1\" font-weight=\"700\" transform=\"translate(6.63 11.52)\">\n    SHOP\n  </text>\n  <path fill=\"#fff\" d=\"M18.9 16.66a1.47 1.47 0 01-1.05-.44 1.38 1.38 0 01-.46-1 1.57 1.57 0 011.51-1.51 1.39 1.39 0 011 .46 1.47 1.47 0 01.44 1 1.43 1.43 0 01-.44 1 1.45 1.45 0 01-1 .49zm-7.87 4.88a3.59 3.59 0 012.65 1.09 3.65 3.65 0 011.07 2.67 3.66 3.66 0 01-3.72 3.73 3.69 3.69 0 01-2.67-1.07 3.57 3.57 0 01-1.09-2.66 3.63 3.63 0 011.09-2.67 3.67 3.67 0 012.67-1.09zm0 6.36a2.58 2.58 0 002.6-2.6 2.56 2.56 0 00-.76-1.86 2.44 2.44 0 00-1.84-.77 2.5 2.5 0 00-1.86.77 2.54 2.54 0 00-.78 1.86 2.49 2.49 0 00.78 1.85 2.56 2.56 0 001.86.75zm4.32-7.48L17 22.14v4.64h-1.47v-3.73l-2.43-2.1a1.19 1.19 0 01-.42-1.06 1.42 1.42 0 01.42-1.05l2.11-2.11a1.19 1.19 0 011.06-.42 1.86 1.86 0 011.19.42l1.44 1.44a3.64 3.64 0 002.67 1.12v1.51a5.14 5.14 0 01-3.79-1.58l-.6-.59zm6.15 1.12a3.72 3.72 0 013.76 3.76 3.57 3.57 0 01-1.09 2.66 3.66 3.66 0 01-2.67 1.07 3.66 3.66 0 01-3.72-3.73 3.65 3.65 0 011.07-2.67 3.59 3.59 0 012.65-1.09zm0 6.36a2.56 2.56 0 001.86-.75 2.49 2.49 0 00.78-1.85 2.54 2.54 0 00-.78-1.86 2.5 2.5 0 00-1.86-.77 2.45 2.45 0 00-1.84.77 2.56 2.56 0 00-.76 1.86 2.58 2.58 0 002.6 2.6z\"/>\n</svg>"
+          "svg": "<svg xmlns=\"http://www.w3.org/2000/svg\" data-name=\"Ebene 1\" viewBox=\"0 0 32.53 32.53\">  <path fill=\"#000001\" d=\"M32.53 16.27A16.27 16.27 0 1116.24 0 16.26 16.26 0 0132.5 16.27\"/>  <text fill=\"#fff\" font-family=\"Interstate-Bold\" font-size=\"7.1\" font-weight=\"700\" transform=\"translate(6.63 11.52)\">    SHOP  </text>  <path fill=\"#fff\" d=\"M18.9 16.66a1.47 1.47 0 01-1.05-.44 1.38 1.38 0 01-.46-1 1.57 1.57 0 011.51-1.51 1.39 1.39 0 011 .46 1.47 1.47 0 01.44 1 1.43 1.43 0 01-.44 1 1.45 1.45 0 01-1 .49zm-7.87 4.88a3.59 3.59 0 012.65 1.09 3.65 3.65 0 011.07 2.67 3.66 3.66 0 01-3.72 3.73 3.69 3.69 0 01-2.67-1.07 3.57 3.57 0 01-1.09-2.66 3.63 3.63 0 011.09-2.67 3.67 3.67 0 012.67-1.09zm0 6.36a2.58 2.58 0 002.6-2.6 2.56 2.56 0 00-.76-1.86 2.44 2.44 0 00-1.84-.77 2.5 2.5 0 00-1.86.77 2.54 2.54 0 00-.78 1.86 2.49 2.49 0 00.78 1.85 2.56 2.56 0 001.86.75zm4.32-7.48L17 22.14v4.64h-1.47v-3.73l-2.43-2.1a1.19 1.19 0 01-.42-1.06 1.42 1.42 0 01.42-1.05l2.11-2.11a1.19 1.19 0 011.06-.42 1.86 1.86 0 011.19.42l1.44 1.44a3.64 3.64 0 002.67 1.12v1.51a5.14 5.14 0 01-3.79-1.58l-.6-.59zm6.15 1.12a3.72 3.72 0 013.76 3.76 3.57 3.57 0 01-1.09 2.66 3.66 3.66 0 01-2.67 1.07 3.66 3.66 0 01-3.72-3.73 3.65 3.65 0 011.07-2.67 3.59 3.59 0 012.65-1.09zm0 6.36a2.56 2.56 0 001.86-.75 2.49 2.49 0 00.78-1.85 2.54 2.54 0 00-.78-1.86 2.5 2.5 0 00-1.86-.77 2.45 2.45 0 00-1.84.77 2.56 2.56 0 00-.76 1.86 2.58 2.58 0 002.6 2.6z\"/></svg>"
         }
       },
       "geometry": {
@@ -240,9 +240,9 @@
         "name": "Radzentrum Nagold",
         "name_en": "Radzentrum Nagold",
         "name_de": "Radzentrum Nagold",
-        "address": "\u00d6ffnungszeiten: Mo 13:00-18:30;Di-Fr 09:30-18:30;So 09:00-16:00, Barrierefrei: ja",
-        "address_de": "\u00d6ffnungszeiten: Mo 13:00-18:30;Di-Fr 09:30-18:30;So 09:00-16:00, Barrierefrei: ja",
-        "address_en": "Opening hours: Mo 13:00-18:30;Tu-Fr 09:30-18:30;Sa 09:00-16:00, Wheelchair: yes",
+        "popupContent": "\u00d6ffnungszeiten: Mo 13:00-18:30;Di-Fr 09:30-18:30;So 09:00-16:00, Barrierefrei: ja",
+        "popupContent_de": "\u00d6ffnungszeiten: Mo 13:00-18:30;Di-Fr 09:30-18:30;So 09:00-16:00, Barrierefrei: ja",
+        "popupContent_en": "Opening hours: Mo 13:00-18:30;Tu-Fr 09:30-18:30;Sa 09:00-16:00, Wheelchair: yes",
         "icon": {
           "id": "bikeShopIcon"
         }
@@ -261,9 +261,9 @@
         "name": "Radsport Kimmerle",
         "name_en": "Radsport Kimmerle",
         "name_de": "Radsport Kimmerle",
-        "address": "Barrierefrei: nein",
-        "address_de": "Barrierefrei: nein",
-        "address_en": "Wheelchair: no",
+        "popupContent": "\u00d6ffnungszeiten: Mo-Fr 09:00-12:30;Mo-Di,Do-Fr 15:00-17:30;So 09:00-13:00, Barrierefrei: nein",
+        "popupContent_de": "\u00d6ffnungszeiten: Mo-Fr 09:00-12:30;Mo-Di,Do-Fr 15:00-17:30;So 09:00-13:00, Barrierefrei: nein",
+        "popupContent_en": "Opening hours: Mo-Fr 09:00-12:30;Mo-Tu,Th-Fr 15:00-17:30;Sa 09:00-13:00, Wheelchair: no",
         "icon": {
           "id": "bikeShopIcon"
         }
@@ -282,9 +282,9 @@
         "name": "Doctor Cycle",
         "name_en": "Doctor Cycle",
         "name_de": "Doctor Cycle",
-        "address": "",
-        "address_de": "",
-        "address_en": "",
+        "popupContent": "",
+        "popupContent_de": "",
+        "popupContent_en": "",
         "icon": {
           "id": "bikeShopIcon"
         }
@@ -303,9 +303,9 @@
         "name": "Holczer Radsport Specialized concept store",
         "name_en": "Holczer Radsport Specialized concept store",
         "name_de": "Holczer Radsport Specialized concept store",
-        "address": "Barrierefrei: ja",
-        "address_de": "Barrierefrei: ja",
-        "address_en": "Wheelchair: yes",
+        "popupContent": "Barrierefrei: ja",
+        "popupContent_de": "Barrierefrei: ja",
+        "popupContent_en": "Wheelchair: yes",
         "icon": {
           "id": "bikeShopIcon"
         }
@@ -324,9 +324,9 @@
         "name": "bikeshop2000",
         "name_en": "bikeshop2000",
         "name_de": "bikeshop2000",
-        "address": "\u00d6ffnungszeiten: Di-Fr 14:00-18:00; So 10:00-14:00;",
-        "address_de": "\u00d6ffnungszeiten: Di-Fr 14:00-18:00; So 10:00-14:00;",
-        "address_en": "Opening hours: Tu-Fr 14:00-18:00; Sa 10:00-14:00;",
+        "popupContent": "\u00d6ffnungszeiten: Di-Fr 14:00-18:00; So 10:00-14:00;",
+        "popupContent_de": "\u00d6ffnungszeiten: Di-Fr 14:00-18:00; So 10:00-14:00;",
+        "popupContent_en": "Opening hours: Tu-Fr 14:00-18:00; Sa 10:00-14:00;",
         "icon": {
           "id": "bikeShopIcon"
         }
@@ -345,9 +345,9 @@
         "name": "Radhof Schill",
         "name_en": "Radhof Schill",
         "name_de": "Radhof Schill",
-        "address": "Barrierefrei: begrenzt",
-        "address_de": "Barrierefrei: begrenzt",
-        "address_en": "Wheelchair: limited",
+        "popupContent": "\u00d6ffnungszeiten: Mo-Di,Do-Fr 09:00-12:30,14:00-18:30;Mi 09:00-12:30;So 09:00-13:00, Barrierefrei: begrenzt",
+        "popupContent_de": "\u00d6ffnungszeiten: Mo-Di,Do-Fr 09:00-12:30,14:00-18:30;Mi 09:00-12:30;So 09:00-13:00, Barrierefrei: begrenzt",
+        "popupContent_en": "Opening hours: Mo-Tu,Th-Fr 09:00-12:30,14:00-18:30;We 09:00-12:30;Sa 09:00-13:00, Wheelchair: limited",
         "icon": {
           "id": "bikeShopIcon"
         }
@@ -366,9 +366,9 @@
         "name": "Radhaus",
         "name_en": "Radhaus",
         "name_de": "Radhaus",
-        "address": "Barrierefrei: nein",
-        "address_de": "Barrierefrei: nein",
-        "address_en": "Wheelchair: no",
+        "popupContent": "Barrierefrei: nein",
+        "popupContent_de": "Barrierefrei: nein",
+        "popupContent_en": "Wheelchair: no",
         "icon": {
           "id": "bikeShopIcon"
         }
@@ -387,9 +387,9 @@
         "name": "Dirty Stuff - Downhill, Freeride, Enduro, Dirt/Street",
         "name_en": "Dirty Stuff - Downhill, Freeride, Enduro, Dirt/Street",
         "name_de": "Dirty Stuff - Downhill, Freeride, Enduro, Dirt/Street",
-        "address": "Telefon: +49 1515 6944213",
-        "address_de": "Telefon: +49 1515 6944213",
-        "address_en": "Phone: +49 1515 6944213",
+        "popupContent": "Telefon: +49 1515 6944213",
+        "popupContent_de": "Telefon: +49 1515 6944213",
+        "popupContent_en": "Phone: +49 1515 6944213",
         "icon": {
           "id": "bikeShopIcon"
         }
@@ -408,9 +408,9 @@
         "name": "Radsport Holczer",
         "name_en": "Radsport Holczer",
         "name_de": "Radsport Holczer",
-        "address": "\u00d6ffnungszeiten: Mo-Di,Fr 09:00-18:30; Do 09:00-20:00; So 09:00-14:00, Barrierefrei: ja",
-        "address_de": "\u00d6ffnungszeiten: Mo-Di,Fr 09:00-18:30; Do 09:00-20:00; So 09:00-14:00, Barrierefrei: ja",
-        "address_en": "Opening hours: Mo-Tu,Fr 09:00-18:30; Th 09:00-20:00; Sa 09:00-14:00, Wheelchair: yes",
+        "popupContent": "\u00d6ffnungszeiten: Mo-Di,Fr 09:00-18:30; Do 09:00-20:00; So 09:00-14:00, Barrierefrei: ja",
+        "popupContent_de": "\u00d6ffnungszeiten: Mo-Di,Fr 09:00-18:30; Do 09:00-20:00; So 09:00-14:00, Barrierefrei: ja",
+        "popupContent_en": "Opening hours: Mo-Tu,Fr 09:00-18:30; Th 09:00-20:00; Sa 09:00-14:00, Wheelchair: yes",
         "icon": {
           "id": "bikeShopIcon"
         }
@@ -429,9 +429,9 @@
         "name": "Sportivo",
         "name_en": "Sportivo",
         "name_de": "Sportivo",
-        "address": "\u00d6ffnungszeiten: Mo-Fr 10:00-19:00; So 10:00-18:00, Barrierefrei: ja",
-        "address_de": "\u00d6ffnungszeiten: Mo-Fr 10:00-19:00; So 10:00-18:00, Barrierefrei: ja",
-        "address_en": "Opening hours: Mo-Fr 10:00-19:00; Sa 10:00-18:00, Wheelchair: yes",
+        "popupContent": "\u00d6ffnungszeiten: Mo-Fr 10:00-19:00; So 10:00-18:00, Barrierefrei: ja",
+        "popupContent_de": "\u00d6ffnungszeiten: Mo-Fr 10:00-19:00; So 10:00-18:00, Barrierefrei: ja",
+        "popupContent_en": "Opening hours: Mo-Fr 10:00-19:00; Sa 10:00-18:00, Wheelchair: yes",
         "icon": {
           "id": "bikeShopIcon"
         }
@@ -450,9 +450,9 @@
         "name_en": "Bicycle shop",
         "name_de": "Fahrradgesch\u00e4ft",
         "name": "Fahrradgesch\u00e4ft",
-        "address": "Barrierefrei: begrenzt",
-        "address_de": "Barrierefrei: begrenzt",
-        "address_en": "Wheelchair: limited",
+        "popupContent": "Barrierefrei: begrenzt",
+        "popupContent_de": "Barrierefrei: begrenzt",
+        "popupContent_en": "Wheelchair: limited",
         "icon": {
           "id": "bikeShopIcon"
         }
@@ -471,9 +471,9 @@
         "name": "D\u00fcll",
         "name_en": "D\u00fcll",
         "name_de": "D\u00fcll",
-        "address": "Barrierefrei: ja",
-        "address_de": "Barrierefrei: ja",
-        "address_en": "Wheelchair: yes",
+        "popupContent": "Barrierefrei: ja",
+        "popupContent_de": "Barrierefrei: ja",
+        "popupContent_en": "Wheelchair: yes",
         "icon": {
           "id": "bikeShopIcon"
         }
@@ -492,9 +492,9 @@
         "name": "Radax",
         "name_en": "Radax",
         "name_de": "Radax",
-        "address": "Barrierefrei: begrenzt",
-        "address_de": "Barrierefrei: begrenzt",
-        "address_en": "Wheelchair: limited",
+        "popupContent": "Barrierefrei: begrenzt",
+        "popupContent_de": "Barrierefrei: begrenzt",
+        "popupContent_en": "Wheelchair: limited",
         "icon": {
           "id": "bikeShopIcon"
         }
@@ -513,9 +513,9 @@
         "name": "H\u00f6lze Fahrradreperatur/Landmaschinen",
         "name_en": "H\u00f6lze Fahrradreperatur/Landmaschinen",
         "name_de": "H\u00f6lze Fahrradreperatur/Landmaschinen",
-        "address": "",
-        "address_de": "",
-        "address_en": "",
+        "popupContent": "",
+        "popupContent_de": "",
+        "popupContent_en": "",
         "icon": {
           "id": "bikeShopIcon"
         }
@@ -534,9 +534,9 @@
         "name": "Zweirad Ohngemach",
         "name_en": "Zweirad Ohngemach",
         "name_de": "Zweirad Ohngemach",
-        "address": "",
-        "address_de": "",
-        "address_en": "",
+        "popupContent": "",
+        "popupContent_de": "",
+        "popupContent_en": "",
         "icon": {
           "id": "bikeShopIcon"
         }
@@ -555,9 +555,9 @@
         "name": "HAICO",
         "name_en": "HAICO",
         "name_de": "HAICO",
-        "address": "Telefon: +49 7073 852520, \u00d6ffnungszeiten: Mo-Di 17:00-20:00, Do-Fr 17:00-20:00, So 10:00-14:00;Barrierefrei: nein",
-        "address_de": "Telefon: +49 7073 852520, \u00d6ffnungszeiten: Mo-Di 17:00-20:00, Do-Fr 17:00-20:00, So 10:00-14:00;Barrierefrei: nein",
-        "address_en": "Phone: +49 7073 852520, Opening hours: Mo-Tu 17:00-20:00, Th-Fr 17:00-20:00, Sa 10:00-14:00;Wheelchair: no",
+        "popupContent": "Telefon: +49 7073 852520, \u00d6ffnungszeiten: Mo-Di 17:00-20:00, Do-Fr 17:00-20:00, So 10:00-14:00;Barrierefrei: nein",
+        "popupContent_de": "Telefon: +49 7073 852520, \u00d6ffnungszeiten: Mo-Di 17:00-20:00, Do-Fr 17:00-20:00, So 10:00-14:00;Barrierefrei: nein",
+        "popupContent_en": "Phone: +49 7073 852520, Opening hours: Mo-Tu 17:00-20:00, Th-Fr 17:00-20:00, Sa 10:00-14:00;Wheelchair: no",
         "icon": {
           "id": "bikeShopIcon"
         }
@@ -576,9 +576,9 @@
         "name": "Bruderhausdiakonie T\u00fcbingen Werkst\u00e4tten Radstall",
         "name_en": "Bruderhausdiakonie T\u00fcbingen Werkst\u00e4tten Radstall",
         "name_de": "Bruderhausdiakonie T\u00fcbingen Werkst\u00e4tten Radstall",
-        "address": "Barrierefrei: ja",
-        "address_de": "Barrierefrei: ja",
-        "address_en": "Wheelchair: yes",
+        "popupContent": "Barrierefrei: ja",
+        "popupContent_de": "Barrierefrei: ja",
+        "popupContent_en": "Wheelchair: yes",
         "icon": {
           "id": "bikeShopIcon"
         }
@@ -597,9 +597,9 @@
         "name": "Bikemaster - Richies Radsportgesch\u00e4ft",
         "name_en": "Bikemaster - Richies Radsportgesch\u00e4ft",
         "name_de": "Bikemaster - Richies Radsportgesch\u00e4ft",
-        "address": "Barrierefrei: nein",
-        "address_de": "Barrierefrei: nein",
-        "address_en": "Wheelchair: no",
+        "popupContent": "Barrierefrei: nein",
+        "popupContent_de": "Barrierefrei: nein",
+        "popupContent_en": "Wheelchair: no",
         "icon": {
           "id": "bikeShopIcon"
         }
@@ -618,9 +618,9 @@
         "name": "Weigl GmbH Zweiradzentrale",
         "name_en": "Weigl GmbH Zweiradzentrale",
         "name_de": "Weigl GmbH Zweiradzentrale",
-        "address": "\u00d6ffnungszeiten: Mo-So 08:30-13:00; Mo 14:00-18:30, Di 14:00-18:30, Do 14:00-18:30, Fr 14:00-18:30, Telefon: +49 7031 700922",
-        "address_de": "\u00d6ffnungszeiten: Mo-So 08:30-13:00; Mo 14:00-18:30, Di 14:00-18:30, Do 14:00-18:30, Fr 14:00-18:30, Telefon: +49 7031 700922",
-        "address_en": "Opening hours: Mo-Sa 08:30-13:00; Mo 14:00-18:30, Tu 14:00-18:30, Th 14:00-18:30, Fr 14:00-18:30, Phone: +49 7031 700922",
+        "popupContent": "\u00d6ffnungszeiten: Mo-So 08:30-13:00; Mo 14:00-18:30, Di 14:00-18:30, Do 14:00-18:30, Fr 14:00-18:30, Telefon: +49 7031 700922",
+        "popupContent_de": "\u00d6ffnungszeiten: Mo-So 08:30-13:00; Mo 14:00-18:30, Di 14:00-18:30, Do 14:00-18:30, Fr 14:00-18:30, Telefon: +49 7031 700922",
+        "popupContent_en": "Opening hours: Mo-Sa 08:30-13:00; Mo 14:00-18:30, Tu 14:00-18:30, Th 14:00-18:30, Fr 14:00-18:30, Phone: +49 7031 700922",
         "icon": {
           "id": "bikeShopIcon"
         }
@@ -639,9 +639,9 @@
         "name": "ZEG Pfrommer",
         "name_en": "ZEG Pfrommer",
         "name_de": "ZEG Pfrommer",
-        "address": "Barrierefrei: ja",
-        "address_de": "Barrierefrei: ja",
-        "address_en": "Wheelchair: yes",
+        "popupContent": "Barrierefrei: ja",
+        "popupContent_de": "Barrierefrei: ja",
+        "popupContent_en": "Wheelchair: yes",
         "icon": {
           "id": "bikeShopIcon"
         }
@@ -660,9 +660,9 @@
         "name": "Die RADgeber",
         "name_en": "Die RADgeber",
         "name_de": "Die RADgeber",
-        "address": "Telefon: +49 7034 652345, \u00d6ffnungszeiten: Mo-Fr 10:00-12:30,14:30-18:30; Mi 10:00-12:30; So 09:00-13:00;Barrierefrei: ja",
-        "address_de": "Telefon: +49 7034 652345, \u00d6ffnungszeiten: Mo-Fr 10:00-12:30,14:30-18:30; Mi 10:00-12:30; So 09:00-13:00;Barrierefrei: ja",
-        "address_en": "Phone: +49 7034 652345, Opening hours: Mo-Fr 10:00-12:30,14:30-18:30; We 10:00-12:30; Sa 09:00-13:00;Wheelchair: yes",
+        "popupContent": "Telefon: +49 7034 652345, \u00d6ffnungszeiten: Mo-Fr 09:00-12:30,14:30-18:30; Mi 09:00-12:30; So 09:00-13:00;Barrierefrei: ja",
+        "popupContent_de": "Telefon: +49 7034 652345, \u00d6ffnungszeiten: Mo-Fr 09:00-12:30,14:30-18:30; Mi 09:00-12:30; So 09:00-13:00;Barrierefrei: ja",
+        "popupContent_en": "Phone: +49 7034 652345, Opening hours: Mo-Fr 09:00-12:30,14:30-18:30; We 09:00-12:30; Sa 09:00-13:00;Wheelchair: yes",
         "icon": {
           "id": "bikeShopIcon"
         }
@@ -681,9 +681,9 @@
         "name_en": "Bicycle shop",
         "name_de": "Fahrradgesch\u00e4ft",
         "name": "Fahrradgesch\u00e4ft",
-        "address": "Barrierefrei: nein",
-        "address_de": "Barrierefrei: nein",
-        "address_en": "Wheelchair: no",
+        "popupContent": "Barrierefrei: nein",
+        "popupContent_de": "Barrierefrei: nein",
+        "popupContent_en": "Wheelchair: no",
         "icon": {
           "id": "bikeShopIcon"
         }
@@ -702,9 +702,9 @@
         "name": "Landhandel Thomas",
         "name_en": "Landhandel Thomas",
         "name_de": "Landhandel Thomas",
-        "address": "",
-        "address_de": "",
-        "address_en": "",
+        "popupContent": "",
+        "popupContent_de": "",
+        "popupContent_en": "",
         "icon": {
           "id": "bikeShopIcon"
         }
@@ -723,9 +723,9 @@
         "name": "Sportshop Haiterbach",
         "name_en": "Sportshop Haiterbach",
         "name_de": "Sportshop Haiterbach",
-        "address": "Telefon: +49 7456 915312, Barrierefrei: nein",
-        "address_de": "Telefon: +49 7456 915312, Barrierefrei: nein",
-        "address_en": "Phone: +49 7456 915312, Wheelchair: no",
+        "popupContent": "Telefon: +49 7456 915312, Barrierefrei: nein",
+        "popupContent_de": "Telefon: +49 7456 915312, Barrierefrei: nein",
+        "popupContent_en": "Phone: +49 7456 915312, Wheelchair: no",
         "icon": {
           "id": "bikeShopIcon"
         }
@@ -744,9 +744,9 @@
         "name": "Radwelt Ehningen",
         "name_en": "Radwelt Ehningen",
         "name_de": "Radwelt Ehningen",
-        "address": "Barrierefrei: ja",
-        "address_de": "Barrierefrei: ja",
-        "address_en": "Wheelchair: yes",
+        "popupContent": "\u00d6ffnungszeiten: Mo-Fr 16:00-18:00; So 10:00-12:00;Barrierefrei: ja",
+        "popupContent_de": "\u00d6ffnungszeiten: Mo-Fr 16:00-18:00; So 10:00-12:00;Barrierefrei: ja",
+        "popupContent_en": "Opening hours: Mo-Fr 16:00-18:00; Sa 10:00-12:00;Wheelchair: yes",
         "icon": {
           "id": "bikeShopIcon"
         }
@@ -754,8 +754,8 @@
       "geometry": {
         "type": "Point",
         "coordinates": [
-          8.9390408,
-          48.6593011
+          8.9398114,
+          48.6593066
         ]
       }
     },
@@ -765,9 +765,9 @@
         "name": "Bikemax",
         "name_en": "Bikemax",
         "name_de": "Bikemax",
-        "address": "\u00d6ffnungszeiten: Mo-Fr 10:00-19:00; So 10:00-18:00, Barrierefrei: nein",
-        "address_de": "\u00d6ffnungszeiten: Mo-Fr 10:00-19:00; So 10:00-18:00, Barrierefrei: nein",
-        "address_en": "Opening hours: Mo-Fr 10:00-19:00; Sa 10:00-18:00, Wheelchair: no",
+        "popupContent": "\u00d6ffnungszeiten: Mo-Fr 10:00-19:00; So 10:00-18:00, Barrierefrei: nein",
+        "popupContent_de": "\u00d6ffnungszeiten: Mo-Fr 10:00-19:00; So 10:00-18:00, Barrierefrei: nein",
+        "popupContent_en": "Opening hours: Mo-Fr 10:00-19:00; Sa 10:00-18:00, Wheelchair: no",
         "icon": {
           "id": "bikeShopIcon"
         }
@@ -786,9 +786,9 @@
         "name": "Radlager",
         "name_en": "Radlager",
         "name_de": "Radlager",
-        "address": "Telefon: +49 7032 795792, \u00d6ffnungszeiten: Mo-Di 09:15-12:30, 14:30-18:30; Do-Fr 09:15-12:30, 14:30-18:30; So 09:15-13:00, Barrierefrei: begrenzt",
-        "address_de": "Telefon: +49 7032 795792, \u00d6ffnungszeiten: Mo-Di 09:15-12:30, 14:30-18:30; Do-Fr 09:15-12:30, 14:30-18:30; So 09:15-13:00, Barrierefrei: begrenzt",
-        "address_en": "Phone: +49 7032 795792, Opening hours: Mo-Tu 09:15-12:30, 14:30-18:30; Th-Fr 09:15-12:30, 14:30-18:30; Sa 09:15-13:00, Wheelchair: limited",
+        "popupContent": "Telefon: +49 7032 795792, \u00d6ffnungszeiten: Mo-Di 09:15-12:30, 14:30-18:30; Do-Fr 09:15-12:30, 14:30-18:30; So 09:15-13:00, Barrierefrei: begrenzt",
+        "popupContent_de": "Telefon: +49 7032 795792, \u00d6ffnungszeiten: Mo-Di 09:15-12:30, 14:30-18:30; Do-Fr 09:15-12:30, 14:30-18:30; So 09:15-13:00, Barrierefrei: begrenzt",
+        "popupContent_en": "Phone: +49 7032 795792, Opening hours: Mo-Tu 09:15-12:30, 14:30-18:30; Th-Fr 09:15-12:30, 14:30-18:30; Sa 09:15-13:00, Wheelchair: limited",
         "icon": {
           "id": "bikeShopIcon"
         }
@@ -807,9 +807,9 @@
         "name": "Ohngemach",
         "name_en": "Ohngemach",
         "name_de": "Ohngemach",
-        "address": "",
-        "address_de": "",
-        "address_en": "",
+        "popupContent": "",
+        "popupContent_de": "",
+        "popupContent_en": "",
         "icon": {
           "id": "bikeShopIcon"
         }

--- a/static/assets/geojson/hb-layers/charging.geojson
+++ b/static/assets/geojson/hb-layers/charging.geojson
@@ -7,12 +7,12 @@
         "name_en": "Bicycle charging station",
         "name_de": "Fahrradladestation",
         "name": "Fahrradladestation",
-        "address": "",
-        "address_de": "",
-        "address_en": "",
+        "popupContent": "",
+        "popupContent_de": "",
+        "popupContent_en": "",
         "icon": {
           "id": "bikeChargeIcon",
-          "svg": "<svg xmlns=\"http://www.w3.org/2000/svg\" id=\"Ebene_1\" data-name=\"Ebene 1\" viewBox=\"0 0 32.53 32.53\">\n  <defs>\n    <style>\n      .cls-2{fill:#fff}\n    </style>\n  </defs>\n  <path fill=\"#00b096\" d=\"M313.29 384.05A16.27 16.27 0 11297 367.78a16.26 16.26 0 0116.26 16.27\" transform=\"translate(-280.76 -367.78)\"/>\n  <path d=\"M299.66 384.43a1.47 1.47 0 01-1.05-.44 1.38 1.38 0 01-.46-1 1.57 1.57 0 011.51-1.51 1.39 1.39 0 011 .46 1.47 1.47 0 01.44 1.05 1.43 1.43 0 01-.44 1 1.45 1.45 0 01-1 .44zm-7.87 4.88a3.59 3.59 0 012.65 1.09 3.65 3.65 0 011.07 2.67 3.66 3.66 0 01-3.72 3.73 3.69 3.69 0 01-2.67-1.07 3.57 3.57 0 01-1.09-2.66 3.63 3.63 0 011.09-2.67 3.67 3.67 0 012.67-1.09zm0 6.36a2.58 2.58 0 002.6-2.6 2.56 2.56 0 00-.76-1.86 2.44 2.44 0 00-1.84-.77 2.5 2.5 0 00-1.86.77 2.54 2.54 0 00-.78 1.86 2.49 2.49 0 00.78 1.85 2.56 2.56 0 001.86.75zm4.32-7.48l1.65 1.72v4.64h-1.47v-3.73l-2.43-2.1a1.19 1.19 0 01-.42-1.06 1.42 1.42 0 01.42-1.05l2.14-2.11a1.19 1.19 0 011.06-.42 1.86 1.86 0 011.19.42l1.44 1.44a3.64 3.64 0 002.67 1.12v1.51a5.14 5.14 0 01-3.79-1.58l-.6-.59zm6.15 1.12a3.72 3.72 0 013.76 3.76 3.57 3.57 0 01-1.09 2.66 3.66 3.66 0 01-2.67 1.07 3.66 3.66 0 01-3.72-3.73 3.65 3.65 0 011.07-2.67 3.59 3.59 0 012.65-1.09zm0 6.36a2.56 2.56 0 001.86-.75 2.49 2.49 0 00.78-1.85 2.54 2.54 0 00-.78-1.86 2.5 2.5 0 00-1.86-.77 2.45 2.45 0 00-1.84.77 2.56 2.56 0 00-.76 1.86 2.58 2.58 0 002.6 2.6zM304.53 378.55a.86.86 0 01-.33.68 1.16 1.16 0 01-.79.28h-12.72a1.07 1.07 0 01-.77-.28.87.87 0 01-.31-.68v-5.17a.87.87 0 01.31-.68 1.07 1.07 0 01.77-.28h12.72a1.16 1.16 0 01.79.28.86.86 0 01.33.68v1.16h1.64v2.85h-1.64zm-13.29-3.28l6.22 2.82v-1.43h4.59l-6.22-2.82v1.43z\" class=\"cls-2\" transform=\"translate(-280.76 -367.78)\"/>\n</svg>"
+          "svg": "<svg xmlns=\"http://www.w3.org/2000/svg\" id=\"Ebene_1\" data-name=\"Ebene 1\" viewBox=\"0 0 32.53 32.53\">  <defs>    <style>      .cls-2{fill:#fff}    </style>  </defs>  <path fill=\"#00b096\" d=\"M313.29 384.05A16.27 16.27 0 11297 367.78a16.26 16.26 0 0116.26 16.27\" transform=\"translate(-280.76 -367.78)\"/>  <path d=\"M299.66 384.43a1.47 1.47 0 01-1.05-.44 1.38 1.38 0 01-.46-1 1.57 1.57 0 011.51-1.51 1.39 1.39 0 011 .46 1.47 1.47 0 01.44 1.05 1.43 1.43 0 01-.44 1 1.45 1.45 0 01-1 .44zm-7.87 4.88a3.59 3.59 0 012.65 1.09 3.65 3.65 0 011.07 2.67 3.66 3.66 0 01-3.72 3.73 3.69 3.69 0 01-2.67-1.07 3.57 3.57 0 01-1.09-2.66 3.63 3.63 0 011.09-2.67 3.67 3.67 0 012.67-1.09zm0 6.36a2.58 2.58 0 002.6-2.6 2.56 2.56 0 00-.76-1.86 2.44 2.44 0 00-1.84-.77 2.5 2.5 0 00-1.86.77 2.54 2.54 0 00-.78 1.86 2.49 2.49 0 00.78 1.85 2.56 2.56 0 001.86.75zm4.32-7.48l1.65 1.72v4.64h-1.47v-3.73l-2.43-2.1a1.19 1.19 0 01-.42-1.06 1.42 1.42 0 01.42-1.05l2.14-2.11a1.19 1.19 0 011.06-.42 1.86 1.86 0 011.19.42l1.44 1.44a3.64 3.64 0 002.67 1.12v1.51a5.14 5.14 0 01-3.79-1.58l-.6-.59zm6.15 1.12a3.72 3.72 0 013.76 3.76 3.57 3.57 0 01-1.09 2.66 3.66 3.66 0 01-2.67 1.07 3.66 3.66 0 01-3.72-3.73 3.65 3.65 0 011.07-2.67 3.59 3.59 0 012.65-1.09zm0 6.36a2.56 2.56 0 001.86-.75 2.49 2.49 0 00.78-1.85 2.54 2.54 0 00-.78-1.86 2.5 2.5 0 00-1.86-.77 2.45 2.45 0 00-1.84.77 2.56 2.56 0 00-.76 1.86 2.58 2.58 0 002.6 2.6zM304.53 378.55a.86.86 0 01-.33.68 1.16 1.16 0 01-.79.28h-12.72a1.07 1.07 0 01-.77-.28.87.87 0 01-.31-.68v-5.17a.87.87 0 01.31-.68 1.07 1.07 0 01.77-.28h12.72a1.16 1.16 0 01.79.28.86.86 0 01.33.68v1.16h1.64v2.85h-1.64zm-13.29-3.28l6.22 2.82v-1.43h4.59l-6.22-2.82v1.43z\" class=\"cls-2\" transform=\"translate(-280.76 -367.78)\"/></svg>"
         }
       },
       "geometry": {
@@ -29,9 +29,9 @@
         "name_en": "Bicycle charging station",
         "name_de": "Fahrradladestation",
         "name": "Fahrradladestation",
-        "address": "Stellpl\u00e4tze: 10",
-        "address_de": "Stellpl\u00e4tze: 10",
-        "address_en": "Capacity: 10",
+        "popupContent": "Stellpl\u00e4tze: 10",
+        "popupContent_de": "Stellpl\u00e4tze: 10",
+        "popupContent_en": "Capacity: 10",
         "icon": {
           "id": "bikeChargeIcon"
         }
@@ -50,9 +50,9 @@
         "name_en": "Bicycle charging station",
         "name_de": "Fahrradladestation",
         "name": "Fahrradladestation",
-        "address": "",
-        "address_de": "",
-        "address_en": "",
+        "popupContent": "",
+        "popupContent_de": "",
+        "popupContent_en": "",
         "icon": {
           "id": "bikeChargeIcon"
         }
@@ -71,9 +71,9 @@
         "name_en": "Bicycle charging station",
         "name_de": "Fahrradladestation",
         "name": "Fahrradladestation",
-        "address": "",
-        "address_de": "",
-        "address_en": "",
+        "popupContent": "",
+        "popupContent_de": "",
+        "popupContent_en": "",
         "icon": {
           "id": "bikeChargeIcon"
         }
@@ -92,9 +92,9 @@
         "name": "bike-energy",
         "name_en": "bike-energy",
         "name_de": "bike-energy",
-        "address": "Stellpl\u00e4tze: 2, Geb\u00fchrenpflichtig:: nein",
-        "address_de": "Stellpl\u00e4tze: 2, Geb\u00fchrenpflichtig:: nein",
-        "address_en": "Capacity: 2, Fee: no",
+        "popupContent": "Stellpl\u00e4tze: 2, Geb\u00fchrenpflichtig: nein",
+        "popupContent_de": "Stellpl\u00e4tze: 2, Geb\u00fchrenpflichtig: nein",
+        "popupContent_en": "Capacity: 2, Fee: no",
         "icon": {
           "id": "bikeChargeIcon"
         }
@@ -113,9 +113,9 @@
         "name": "bike-energy",
         "name_en": "bike-energy",
         "name_de": "bike-energy",
-        "address": "Stellpl\u00e4tze: 2, Geb\u00fchrenpflichtig:: nein",
-        "address_de": "Stellpl\u00e4tze: 2, Geb\u00fchrenpflichtig:: nein",
-        "address_en": "Capacity: 2, Fee: no",
+        "popupContent": "Stellpl\u00e4tze: 2, Geb\u00fchrenpflichtig: nein",
+        "popupContent_de": "Stellpl\u00e4tze: 2, Geb\u00fchrenpflichtig: nein",
+        "popupContent_en": "Capacity: 2, Fee: no",
         "icon": {
           "id": "bikeChargeIcon"
         }
@@ -134,9 +134,9 @@
         "name_en": "Bicycle charging station",
         "name_de": "Fahrradladestation",
         "name": "Fahrradladestation",
-        "address": "Stellpl\u00e4tze: 2",
-        "address_de": "Stellpl\u00e4tze: 2",
-        "address_en": "Capacity: 2",
+        "popupContent": "Stellpl\u00e4tze: 2",
+        "popupContent_de": "Stellpl\u00e4tze: 2",
+        "popupContent_en": "Capacity: 2",
         "icon": {
           "id": "bikeChargeIcon"
         }
@@ -155,12 +155,12 @@
         "name_en": "Car charging station",
         "name_de": "Elektroauto-Ladestation",
         "name": "Elektroauto-Ladestation",
-        "address": "Stellpl\u00e4tze: 1",
-        "address_de": "Stellpl\u00e4tze: 1",
-        "address_en": "Capacity: 1",
+        "popupContent": "Stellpl\u00e4tze: 1",
+        "popupContent_de": "Stellpl\u00e4tze: 1",
+        "popupContent_en": "Capacity: 1",
         "icon": {
           "id": "carChargeIcon",
-          "svg": "<svg xmlns=\"http://www.w3.org/2000/svg\" id=\"Ebene_1\" data-name=\"Ebene 1\" viewBox=\"0 0 32.53 32.53\">\n  <defs>\n    <style>\n      .cls-1{fill:#00b096}.cls-2{fill:#fff}\n    </style>\n  </defs>\n  <path d=\"M313.29 384.05A16.27 16.27 0 11297 367.78a16.26 16.26 0 0116.26 16.27\" class=\"cls-1\" transform=\"translate(-280.76 -367.78)\"/>\n  <path d=\"M304.53 378.55a.86.86 0 01-.33.68 1.16 1.16 0 01-.79.28h-12.72a1.07 1.07 0 01-.77-.28.87.87 0 01-.31-.68v-5.17a.87.87 0 01.31-.68 1.07 1.07 0 01.77-.28h12.72a1.16 1.16 0 01.79.28.86.86 0 01.33.68v1.16h1.64v2.85h-1.64zm-13.29-3.28l6.22 2.82v-1.43h4.59l-6.22-2.82v1.43zM293.43 382.05h-.6a2 2 0 00-1.75 1.17l-.88 2.16-.83-.23h-.24a.73.73 0 00-.74.77v.46a1 1 0 001 .95h.06l-.13.31a7 7 0 00-.45 2.27v4.3a1 1 0 00.95.95h1.15a1 1 0 00.95-.95v-1.06h10.28v1.06a1 1 0 00.95.95h1.15a1 1 0 00.95-.95v-4.3a7 7 0 00-.45-2.27l-.13-.31h.08a1 1 0 001-.95v-.46a.73.73 0 00-.74-.77h-.24l-.84.23-.88-2.16a2 2 0 00-1.75-1.17h-.59m-9.75 4.72l1.34-3.28a1.23 1.23 0 011.05-.7h7.52a1.21 1.21 0 011 .7l1.35 3.28a.47.47 0 01-.47.7h-11.41a.47.47 0 01-.47-.7z\" class=\"cls-2\" transform=\"translate(-280.76 -367.78)\"/>\n  <circle cx=\"10.7\" cy=\"22.47\" r=\"1.22\" class=\"cls-1\"/>\n  <circle cx=\"21.93\" cy=\"22.47\" r=\"1.22\" class=\"cls-1\"/>\n</svg>"
+          "svg": "<svg xmlns=\"http://www.w3.org/2000/svg\" id=\"Ebene_1\" data-name=\"Ebene 1\" viewBox=\"0 0 32.53 32.53\">  <defs>    <style>      .cls-1{fill:#00b096}.cls-2{fill:#fff}    </style>  </defs>  <path d=\"M313.29 384.05A16.27 16.27 0 11297 367.78a16.26 16.26 0 0116.26 16.27\" class=\"cls-1\" transform=\"translate(-280.76 -367.78)\"/>  <path d=\"M304.53 378.55a.86.86 0 01-.33.68 1.16 1.16 0 01-.79.28h-12.72a1.07 1.07 0 01-.77-.28.87.87 0 01-.31-.68v-5.17a.87.87 0 01.31-.68 1.07 1.07 0 01.77-.28h12.72a1.16 1.16 0 01.79.28.86.86 0 01.33.68v1.16h1.64v2.85h-1.64zm-13.29-3.28l6.22 2.82v-1.43h4.59l-6.22-2.82v1.43zM293.43 382.05h-.6a2 2 0 00-1.75 1.17l-.88 2.16-.83-.23h-.24a.73.73 0 00-.74.77v.46a1 1 0 001 .95h.06l-.13.31a7 7 0 00-.45 2.27v4.3a1 1 0 00.95.95h1.15a1 1 0 00.95-.95v-1.06h10.28v1.06a1 1 0 00.95.95h1.15a1 1 0 00.95-.95v-4.3a7 7 0 00-.45-2.27l-.13-.31h.08a1 1 0 001-.95v-.46a.73.73 0 00-.74-.77h-.24l-.84.23-.88-2.16a2 2 0 00-1.75-1.17h-.59m-9.75 4.72l1.34-3.28a1.23 1.23 0 011.05-.7h7.52a1.21 1.21 0 011 .7l1.35 3.28a.47.47 0 01-.47.7h-11.41a.47.47 0 01-.47-.7z\" class=\"cls-2\" transform=\"translate(-280.76 -367.78)\"/>  <circle cx=\"10.7\" cy=\"22.47\" r=\"1.22\" class=\"cls-1\"/>  <circle cx=\"21.93\" cy=\"22.47\" r=\"1.22\" class=\"cls-1\"/></svg>"
         }
       },
       "geometry": {
@@ -177,9 +177,9 @@
         "name_en": "Car charging station",
         "name_de": "Elektroauto-Ladestation",
         "name": "Elektroauto-Ladestation",
-        "address": "\u00d6ffnungszeiten: 24/7",
-        "address_de": "\u00d6ffnungszeiten: 24/7",
-        "address_en": "Opening hours: 24/7",
+        "popupContent": "\u00d6ffnungszeiten: 24/7",
+        "popupContent_de": "\u00d6ffnungszeiten: 24/7",
+        "popupContent_en": "Opening hours: 24/7",
         "icon": {
           "id": "carChargeIcon"
         }
@@ -198,9 +198,9 @@
         "name_en": "Car charging station",
         "name_de": "Elektroauto-Ladestation",
         "name": "Elektroauto-Ladestation",
-        "address": "Stellpl\u00e4tze: 2, Geb\u00fchrenpflichtig:: nein, \u00d6ffnungszeiten: 24/7",
-        "address_de": "Stellpl\u00e4tze: 2, Geb\u00fchrenpflichtig:: nein, \u00d6ffnungszeiten: 24/7",
-        "address_en": "Capacity: 2, Fee: no, Opening hours: 24/7",
+        "popupContent": "Stellpl\u00e4tze: 2, Geb\u00fchrenpflichtig: nein, \u00d6ffnungszeiten: 24/7",
+        "popupContent_de": "Stellpl\u00e4tze: 2, Geb\u00fchrenpflichtig: nein, \u00d6ffnungszeiten: 24/7",
+        "popupContent_en": "Capacity: 2, Fee: no, Opening hours: 24/7",
         "icon": {
           "id": "carChargeIcon"
         }
@@ -219,9 +219,9 @@
         "name_en": "Car charging station",
         "name_de": "Elektroauto-Ladestation",
         "name": "Elektroauto-Ladestation",
-        "address": "Stellpl\u00e4tze: 2",
-        "address_de": "Stellpl\u00e4tze: 2",
-        "address_en": "Capacity: 2",
+        "popupContent": "Stellpl\u00e4tze: 2",
+        "popupContent_de": "Stellpl\u00e4tze: 2",
+        "popupContent_en": "Capacity: 2",
         "icon": {
           "id": "carChargeIcon"
         }
@@ -240,9 +240,9 @@
         "name_en": "Car charging station",
         "name_de": "Elektroauto-Ladestation",
         "name": "Elektroauto-Ladestation",
-        "address": "Stellpl\u00e4tze: 2",
-        "address_de": "Stellpl\u00e4tze: 2",
-        "address_en": "Capacity: 2",
+        "popupContent": "Stellpl\u00e4tze: 2",
+        "popupContent_de": "Stellpl\u00e4tze: 2",
+        "popupContent_en": "Capacity: 2",
         "icon": {
           "id": "carChargeIcon"
         }
@@ -261,9 +261,9 @@
         "name_en": "Car charging station",
         "name_de": "Elektroauto-Ladestation",
         "name": "Elektroauto-Ladestation",
-        "address": "Stellpl\u00e4tze: 2, \u00d6ffnungszeiten: 24/7",
-        "address_de": "Stellpl\u00e4tze: 2, \u00d6ffnungszeiten: 24/7",
-        "address_en": "Capacity: 2, Opening hours: 24/7",
+        "popupContent": "Stellpl\u00e4tze: 2, \u00d6ffnungszeiten: 24/7",
+        "popupContent_de": "Stellpl\u00e4tze: 2, \u00d6ffnungszeiten: 24/7",
+        "popupContent_en": "Capacity: 2, Opening hours: 24/7",
         "icon": {
           "id": "carChargeIcon"
         }
@@ -282,9 +282,9 @@
         "name_en": "Car charging station",
         "name_de": "Elektroauto-Ladestation",
         "name": "Elektroauto-Ladestation",
-        "address": "Stellpl\u00e4tze: 12, Geb\u00fchrenpflichtig:: ja, \u00d6ffnungszeiten: 24/7",
-        "address_de": "Stellpl\u00e4tze: 12, Geb\u00fchrenpflichtig:: ja, \u00d6ffnungszeiten: 24/7",
-        "address_en": "Capacity: 12, Fee: yes, Opening hours: 24/7",
+        "popupContent": "Stellpl\u00e4tze: 12, Geb\u00fchrenpflichtig: ja, \u00d6ffnungszeiten: 24/7",
+        "popupContent_de": "Stellpl\u00e4tze: 12, Geb\u00fchrenpflichtig: ja, \u00d6ffnungszeiten: 24/7",
+        "popupContent_en": "Capacity: 12, Fee: yes, Opening hours: 24/7",
         "icon": {
           "id": "carChargeIcon"
         }
@@ -303,9 +303,9 @@
         "name": "Aldi S\u00fcd Ladestation",
         "name_en": "Aldi S\u00fcd Ladestation",
         "name_de": "Aldi S\u00fcd Ladestation",
-        "address": "Stellpl\u00e4tze: 2, Geb\u00fchrenpflichtig:: nein",
-        "address_de": "Stellpl\u00e4tze: 2, Geb\u00fchrenpflichtig:: nein",
-        "address_en": "Capacity: 2, Fee: no",
+        "popupContent": "Stellpl\u00e4tze: 2, Geb\u00fchrenpflichtig: nein",
+        "popupContent_de": "Stellpl\u00e4tze: 2, Geb\u00fchrenpflichtig: nein",
+        "popupContent_en": "Capacity: 2, Fee: no",
         "icon": {
           "id": "carChargeIcon"
         }
@@ -324,9 +324,9 @@
         "name": "Sch\u00f6nbuch West",
         "name_en": "Sch\u00f6nbuch West",
         "name_de": "Sch\u00f6nbuch West",
-        "address": "\u00d6ffnungszeiten: 24/7",
-        "address_de": "\u00d6ffnungszeiten: 24/7",
-        "address_en": "Opening hours: 24/7",
+        "popupContent": "\u00d6ffnungszeiten: 24/7",
+        "popupContent_de": "\u00d6ffnungszeiten: 24/7",
+        "popupContent_en": "Opening hours: 24/7",
         "icon": {
           "id": "carChargeIcon"
         }
@@ -345,9 +345,9 @@
         "name": "Sch\u00f6nbuch West",
         "name_en": "Sch\u00f6nbuch West",
         "name_de": "Sch\u00f6nbuch West",
-        "address": "\u00d6ffnungszeiten: 24/7",
-        "address_de": "\u00d6ffnungszeiten: 24/7",
-        "address_en": "Opening hours: 24/7",
+        "popupContent": "\u00d6ffnungszeiten: 24/7",
+        "popupContent_de": "\u00d6ffnungszeiten: 24/7",
+        "popupContent_en": "Opening hours: 24/7",
         "icon": {
           "id": "carChargeIcon"
         }
@@ -366,9 +366,9 @@
         "name": "Sch\u00f6nbuch Ost",
         "name_en": "Sch\u00f6nbuch Ost",
         "name_de": "Sch\u00f6nbuch Ost",
-        "address": "\u00d6ffnungszeiten: 24/7",
-        "address_de": "\u00d6ffnungszeiten: 24/7",
-        "address_en": "Opening hours: 24/7",
+        "popupContent": "\u00d6ffnungszeiten: 24/7",
+        "popupContent_de": "\u00d6ffnungszeiten: 24/7",
+        "popupContent_en": "Opening hours: 24/7",
         "icon": {
           "id": "carChargeIcon"
         }
@@ -387,9 +387,9 @@
         "name": "Sch\u00f6nbuch Ost",
         "name_en": "Sch\u00f6nbuch Ost",
         "name_de": "Sch\u00f6nbuch Ost",
-        "address": "\u00d6ffnungszeiten: 24/7",
-        "address_de": "\u00d6ffnungszeiten: 24/7",
-        "address_en": "Opening hours: 24/7",
+        "popupContent": "\u00d6ffnungszeiten: 24/7",
+        "popupContent_de": "\u00d6ffnungszeiten: 24/7",
+        "popupContent_en": "Opening hours: 24/7",
         "icon": {
           "id": "carChargeIcon"
         }
@@ -408,9 +408,9 @@
         "name_en": "Car charging station",
         "name_de": "Elektroauto-Ladestation",
         "name": "Elektroauto-Ladestation",
-        "address": "",
-        "address_de": "",
-        "address_en": "",
+        "popupContent": "",
+        "popupContent_de": "",
+        "popupContent_en": "",
         "icon": {
           "id": "carChargeIcon"
         }
@@ -426,12 +426,12 @@
     {
       "type": "Feature",
       "properties": {
-        "name": "Weiler W\u00e4rem",
-        "name_en": "Weiler W\u00e4rem",
-        "name_de": "Weiler W\u00e4rem",
-        "address": "Geb\u00fchrenpflichtig:: nein",
-        "address_de": "Geb\u00fchrenpflichtig:: nein",
-        "address_en": "Fee: no",
+        "name": "Weiler W\u00e4rme",
+        "name_en": "Weiler W\u00e4rme",
+        "name_de": "Weiler W\u00e4rme",
+        "popupContent": "Geb\u00fchrenpflichtig: nein",
+        "popupContent_de": "Geb\u00fchrenpflichtig: nein",
+        "popupContent_en": "Fee: no",
         "icon": {
           "id": "carChargeIcon"
         }
@@ -450,9 +450,9 @@
         "name_en": "Car charging station",
         "name_de": "Elektroauto-Ladestation",
         "name": "Elektroauto-Ladestation",
-        "address": "Stellpl\u00e4tze: 1",
-        "address_de": "Stellpl\u00e4tze: 1",
-        "address_en": "Capacity: 1",
+        "popupContent": "Stellpl\u00e4tze: 1",
+        "popupContent_de": "Stellpl\u00e4tze: 1",
+        "popupContent_en": "Capacity: 1",
         "icon": {
           "id": "carChargeIcon"
         }
@@ -471,9 +471,9 @@
         "name_en": "Car charging station",
         "name_de": "Elektroauto-Ladestation",
         "name": "Elektroauto-Ladestation",
-        "address": "Stellpl\u00e4tze: 2",
-        "address_de": "Stellpl\u00e4tze: 2",
-        "address_en": "Capacity: 2",
+        "popupContent": "Stellpl\u00e4tze: 2",
+        "popupContent_de": "Stellpl\u00e4tze: 2",
+        "popupContent_en": "Capacity: 2",
         "icon": {
           "id": "carChargeIcon"
         }
@@ -492,9 +492,9 @@
         "name_en": "Car charging station",
         "name_de": "Elektroauto-Ladestation",
         "name": "Elektroauto-Ladestation",
-        "address": "Stellpl\u00e4tze: 4, Geb\u00fchrenpflichtig:: ja, \u00d6ffnungszeiten: 24/7",
-        "address_de": "Stellpl\u00e4tze: 4, Geb\u00fchrenpflichtig:: ja, \u00d6ffnungszeiten: 24/7",
-        "address_en": "Capacity: 4, Fee: yes, Opening hours: 24/7",
+        "popupContent": "Stellpl\u00e4tze: 4, Geb\u00fchrenpflichtig: ja, \u00d6ffnungszeiten: 24/7",
+        "popupContent_de": "Stellpl\u00e4tze: 4, Geb\u00fchrenpflichtig: ja, \u00d6ffnungszeiten: 24/7",
+        "popupContent_en": "Capacity: 4, Fee: yes, Opening hours: 24/7",
         "icon": {
           "id": "carChargeIcon"
         }
@@ -513,9 +513,9 @@
         "name_en": "Car charging station",
         "name_de": "Elektroauto-Ladestation",
         "name": "Elektroauto-Ladestation",
-        "address": "Stellpl\u00e4tze: 2, Geb\u00fchrenpflichtig:: ja, \u00d6ffnungszeiten: 24/7",
-        "address_de": "Stellpl\u00e4tze: 2, Geb\u00fchrenpflichtig:: ja, \u00d6ffnungszeiten: 24/7",
-        "address_en": "Capacity: 2, Fee: yes, Opening hours: 24/7",
+        "popupContent": "Stellpl\u00e4tze: 2, Geb\u00fchrenpflichtig: ja, \u00d6ffnungszeiten: 24/7",
+        "popupContent_de": "Stellpl\u00e4tze: 2, Geb\u00fchrenpflichtig: ja, \u00d6ffnungszeiten: 24/7",
+        "popupContent_en": "Capacity: 2, Fee: yes, Opening hours: 24/7",
         "icon": {
           "id": "carChargeIcon"
         }
@@ -534,9 +534,9 @@
         "name_en": "Car charging station",
         "name_de": "Elektroauto-Ladestation",
         "name": "Elektroauto-Ladestation",
-        "address": "Geb\u00fchrenpflichtig:: nein",
-        "address_de": "Geb\u00fchrenpflichtig:: nein",
-        "address_en": "Fee: no",
+        "popupContent": "Geb\u00fchrenpflichtig: nein",
+        "popupContent_de": "Geb\u00fchrenpflichtig: nein",
+        "popupContent_en": "Fee: no",
         "icon": {
           "id": "carChargeIcon"
         }
@@ -555,9 +555,9 @@
         "name_en": "Car charging station",
         "name_de": "Elektroauto-Ladestation",
         "name": "Elektroauto-Ladestation",
-        "address": "Geb\u00fchrenpflichtig:: nein",
-        "address_de": "Geb\u00fchrenpflichtig:: nein",
-        "address_en": "Fee: no",
+        "popupContent": "Geb\u00fchrenpflichtig: nein",
+        "popupContent_de": "Geb\u00fchrenpflichtig: nein",
+        "popupContent_en": "Fee: no",
         "icon": {
           "id": "carChargeIcon"
         }
@@ -576,9 +576,9 @@
         "name_en": "Car charging station",
         "name_de": "Elektroauto-Ladestation",
         "name": "Elektroauto-Ladestation",
-        "address": "Stellpl\u00e4tze: 2",
-        "address_de": "Stellpl\u00e4tze: 2",
-        "address_en": "Capacity: 2",
+        "popupContent": "Stellpl\u00e4tze: 2",
+        "popupContent_de": "Stellpl\u00e4tze: 2",
+        "popupContent_en": "Capacity: 2",
         "icon": {
           "id": "carChargeIcon"
         }
@@ -597,51 +597,9 @@
         "name_en": "Car charging station",
         "name_de": "Elektroauto-Ladestation",
         "name": "Elektroauto-Ladestation",
-        "address": "Stellpl\u00e4tze: 2, Geb\u00fchrenpflichtig:: ja, \u00d6ffnungszeiten: 24/7",
-        "address_de": "Stellpl\u00e4tze: 2, Geb\u00fchrenpflichtig:: ja, \u00d6ffnungszeiten: 24/7",
-        "address_en": "Capacity: 2, Fee: yes, Opening hours: 24/7",
-        "icon": {
-          "id": "carChargeIcon"
-        }
-      },
-      "geometry": {
-        "type": "Point",
-        "coordinates": [
-          8.9645138,
-          48.5318748
-        ]
-      }
-    },
-    {
-      "type": "Feature",
-      "properties": {
-        "name_en": "Car charging station",
-        "name_de": "Elektroauto-Ladestation",
-        "name": "Elektroauto-Ladestation",
-        "address": "Stellpl\u00e4tze: 2, Geb\u00fchrenpflichtig:: ja, \u00d6ffnungszeiten: 24/7",
-        "address_de": "Stellpl\u00e4tze: 2, Geb\u00fchrenpflichtig:: ja, \u00d6ffnungszeiten: 24/7",
-        "address_en": "Capacity: 2, Fee: yes, Opening hours: 24/7",
-        "icon": {
-          "id": "carChargeIcon"
-        }
-      },
-      "geometry": {
-        "type": "Point",
-        "coordinates": [
-          8.9657114,
-          48.554873
-        ]
-      }
-    },
-    {
-      "type": "Feature",
-      "properties": {
-        "name_en": "Car charging station",
-        "name_de": "Elektroauto-Ladestation",
-        "name": "Elektroauto-Ladestation",
-        "address": "",
-        "address_de": "",
-        "address_en": "",
+        "popupContent": "",
+        "popupContent_de": "",
+        "popupContent_en": "",
         "icon": {
           "id": "carChargeIcon"
         }

--- a/static/assets/geojson/hb-layers/taxi-and-sharing.geojson
+++ b/static/assets/geojson/hb-layers/taxi-and-sharing.geojson
@@ -7,12 +7,12 @@
         "name_en": "Taxi stand",
         "name_de": "Taxi-Stellplatz",
         "name": "Taxi-Stellplatz",
-        "address": "",
-        "address_de": "",
-        "address_en": "",
+        "popupContent": "",
+        "popupContent_de": "",
+        "popupContent_en": "",
         "icon": {
           "id": "taxiIcon",
-          "svg": "<svg xmlns=\"http://www.w3.org/2000/svg\" id=\"Ebene_1\" data-name=\"Ebene 1\" viewBox=\"0 0 32.53 32.53\">\n  <defs>\n    <style>\n      .cls-2{fill:#fff}\n    </style>\n  </defs>\n  <path fill=\"#f1b736\" d=\"M313.29 384.05A16.27 16.27 0 11297 367.78a16.27 16.27 0 0116.26 16.27\" transform=\"translate(-280.76 -367.78)\"/>\n  <path d=\"M306.79 379.63a1.54 1.54 0 00-.3 0l-1 .29-1.1-2.67a2.53 2.53 0 00-2.16-1.45h-.73v-2.21a.71.71 0 00-.71-.71h-7.47a.71.71 0 00-.71.71v2.21h-.74a2.51 2.51 0 00-2.16 1.45l-1.1 2.67-1-.29a1.54 1.54 0 00-.3 0 .91.91 0 00-.91 1v.57a1.17 1.17 0 001.18 1.17h.07l-.15.39a8.66 8.66 0 00-.55 2.8v5.33a1.17 1.17 0 001.17 1.17h1.41a1.18 1.18 0 001.18-1.17v-1.31h12.72v1.31a1.17 1.17 0 001.17 1.17h1.4a1.18 1.18 0 001.17-1.17v-5.33a8.93 8.93 0 00-.55-2.8l-.16-.39h.09a1.17 1.17 0 001.18-1.17v-.57a.91.91 0 00-.94-1zm-6.93-5.77h.54v2h-.58zm-3.9 0h.65l.78 1.95.71-.88-.68-1h.61l.35.57.35-.57h.61l-.68 1 .72.9h-.63l-.4-.63-.4.63h-1.21l-.14-.41h-.74l-.14.41h-.58l.79-2zm-1.91 2v-1.55h-.65v-.35h2v.35h-.66v1.55h-.58zm-4.64 5.86l1.67-4.06a1.53 1.53 0 011.29-.87h9.29a1.54 1.54 0 011.3.87l1.66 4.06a.58.58 0 01-.58.87H290a.59.59 0 01-.59-.91zm3.76 5.22a.47.47 0 01-.47.47h-3.18a.48.48 0 01-.47-.47v-1.5a.48.48 0 01.47-.48h3.18a.48.48 0 01.47.48zm11.78 0a.47.47 0 01-.47.47h-3.18a.47.47 0 01-.47-.47v-1.5a.48.48 0 01.47-.48h3.18a.48.48 0 01.47.48z\" class=\"cls-2\" transform=\"translate(-280.76 -367.78)\"/>\n  <path d=\"M296.52 375l-.23-.54-.29.54z\" class=\"cls-2\" transform=\"translate(-280.76 -367.78)\"/>\n</svg>"
+          "svg": "<svg xmlns=\"http://www.w3.org/2000/svg\" id=\"Ebene_1\" data-name=\"Ebene 1\" viewBox=\"0 0 32.53 32.53\">  <defs>    <style>      .cls-2{fill:#fff}    </style>  </defs>  <path fill=\"#f1b736\" d=\"M313.29 384.05A16.27 16.27 0 11297 367.78a16.27 16.27 0 0116.26 16.27\" transform=\"translate(-280.76 -367.78)\"/>  <path d=\"M306.79 379.63a1.54 1.54 0 00-.3 0l-1 .29-1.1-2.67a2.53 2.53 0 00-2.16-1.45h-.73v-2.21a.71.71 0 00-.71-.71h-7.47a.71.71 0 00-.71.71v2.21h-.74a2.51 2.51 0 00-2.16 1.45l-1.1 2.67-1-.29a1.54 1.54 0 00-.3 0 .91.91 0 00-.91 1v.57a1.17 1.17 0 001.18 1.17h.07l-.15.39a8.66 8.66 0 00-.55 2.8v5.33a1.17 1.17 0 001.17 1.17h1.41a1.18 1.18 0 001.18-1.17v-1.31h12.72v1.31a1.17 1.17 0 001.17 1.17h1.4a1.18 1.18 0 001.17-1.17v-5.33a8.93 8.93 0 00-.55-2.8l-.16-.39h.09a1.17 1.17 0 001.18-1.17v-.57a.91.91 0 00-.94-1zm-6.93-5.77h.54v2h-.58zm-3.9 0h.65l.78 1.95.71-.88-.68-1h.61l.35.57.35-.57h.61l-.68 1 .72.9h-.63l-.4-.63-.4.63h-1.21l-.14-.41h-.74l-.14.41h-.58l.79-2zm-1.91 2v-1.55h-.65v-.35h2v.35h-.66v1.55h-.58zm-4.64 5.86l1.67-4.06a1.53 1.53 0 011.29-.87h9.29a1.54 1.54 0 011.3.87l1.66 4.06a.58.58 0 01-.58.87H290a.59.59 0 01-.59-.91zm3.76 5.22a.47.47 0 01-.47.47h-3.18a.48.48 0 01-.47-.47v-1.5a.48.48 0 01.47-.48h3.18a.48.48 0 01.47.48zm11.78 0a.47.47 0 01-.47.47h-3.18a.47.47 0 01-.47-.47v-1.5a.48.48 0 01.47-.48h3.18a.48.48 0 01.47.48z\" class=\"cls-2\" transform=\"translate(-280.76 -367.78)\"/>  <path d=\"M296.52 375l-.23-.54-.29.54z\" class=\"cls-2\" transform=\"translate(-280.76 -367.78)\"/></svg>"
         }
       },
       "geometry": {
@@ -29,9 +29,9 @@
         "name_en": "Taxi stand",
         "name_de": "Taxi-Stellplatz",
         "name": "Taxi-Stellplatz",
-        "address": "",
-        "address_de": "",
-        "address_en": "",
+        "popupContent": "",
+        "popupContent_de": "",
+        "popupContent_en": "",
         "icon": {
           "id": "taxiIcon"
         }
@@ -50,9 +50,9 @@
         "name_en": "Taxi stand",
         "name_de": "Taxi-Stellplatz",
         "name": "Taxi-Stellplatz",
-        "address": "",
-        "address_de": "",
-        "address_en": "",
+        "popupContent": "",
+        "popupContent_de": "",
+        "popupContent_en": "",
         "icon": {
           "id": "taxiIcon"
         }
@@ -71,9 +71,9 @@
         "name": "Marktplatz",
         "name_en": "Marktplatz",
         "name_de": "Marktplatz",
-        "address": "",
-        "address_de": "",
-        "address_en": "",
+        "popupContent": "",
+        "popupContent_de": "",
+        "popupContent_en": "",
         "icon": {
           "id": "taxiIcon"
         }
@@ -92,9 +92,9 @@
         "name": "Stern Center",
         "name_en": "Stern Center",
         "name_de": "Stern Center",
-        "address": "",
-        "address_de": "",
-        "address_en": "",
+        "popupContent": "",
+        "popupContent_de": "",
+        "popupContent_en": "",
         "icon": {
           "id": "taxiIcon"
         }
@@ -113,9 +113,9 @@
         "name": "Taxi Schmid",
         "name_en": "Taxi Schmid",
         "name_de": "Taxi Schmid",
-        "address": "",
-        "address_de": "",
-        "address_en": "",
+        "popupContent": "",
+        "popupContent_de": "",
+        "popupContent_en": "",
         "icon": {
           "id": "taxiIcon"
         }
@@ -134,9 +134,9 @@
         "name_en": "Taxi stand",
         "name_de": "Taxi-Stellplatz",
         "name": "Taxi-Stellplatz",
-        "address": "",
-        "address_de": "",
-        "address_en": "",
+        "popupContent": "",
+        "popupContent_de": "",
+        "popupContent_en": "",
         "icon": {
           "id": "taxiIcon"
         }
@@ -155,9 +155,9 @@
         "name": "Taxi Winter",
         "name_en": "Taxi Winter",
         "name_de": "Taxi Winter",
-        "address": "Telefon: +49 7034 7494",
-        "address_de": "Telefon: +49 7034 7494",
-        "address_en": "Phone: +49 7034 7494",
+        "popupContent": "Telefon: +49 7034 7494",
+        "popupContent_de": "Telefon: +49 7034 7494",
+        "popupContent_en": "Phone: +49 7034 7494",
         "icon": {
           "id": "taxiIcon"
         }
@@ -176,9 +176,9 @@
         "name": "Fuchs Mobil",
         "name_en": "Fuchs Mobil",
         "name_de": "Fuchs Mobil",
-        "address": "Telefon: +49 7073 1839700",
-        "address_de": "Telefon: +49 7073 1839700",
-        "address_en": "Phone: +49 7073 1839700",
+        "popupContent": "Telefon: +49 7073 1839700",
+        "popupContent_de": "Telefon: +49 7073 1839700",
+        "popupContent_en": "Phone: +49 7073 1839700",
         "icon": {
           "id": "taxiIcon"
         }
@@ -197,12 +197,12 @@
         "name": "B\u00f6blingen",
         "name_en": "B\u00f6blingen",
         "name_de": "B\u00f6blingen",
-        "address": "Stellpl\u00e4tze: 1, Barrierefrei: ja",
-        "address_de": "Stellpl\u00e4tze: 1, Barrierefrei: ja",
-        "address_en": "Capacity: 1, Wheelchair: yes",
+        "popupContent": "Stellpl\u00e4tze: 1, Barrierefrei: ja",
+        "popupContent_de": "Stellpl\u00e4tze: 1, Barrierefrei: ja",
+        "popupContent_en": "Capacity: 1, Wheelchair: yes",
         "icon": {
           "id": "carShareIcon",
-          "svg": "<svg xmlns=\"http://www.w3.org/2000/svg\" id=\"Ebene_1\" data-name=\"Ebene 1\" viewBox=\"0 0 32.53 32.53\">\n  <defs>\n    <style>\n      .cls-2{fill:#fff}\n    </style>\n  </defs>\n  <path fill=\"#ff834a\" d=\"M320.34 384.05a16.27 16.27 0 11-16.26-16.27 16.26 16.26 0 0116.26 16.27\" transform=\"translate(-287.81 -367.78)\"/>\n  <path d=\"M304.35 370.35a4.7 4.7 0 11-3.3 8l.73-.76a3.5 3.5 0 002.57 1.08 3.56 3.56 0 002.59-1.07 3.62 3.62 0 000-5.16 3.55 3.55 0 00-2.59-1.06 3.64 3.64 0 00-3.65 3.64h1.57l-2.1 2.1-.05-.07-2-2h1.56a4.69 4.69 0 014.7-4.7zm-.51 2.62h.78v2.2l1.83 1.1-.39.64-2.22-1.35zM312 385.46a.67.67 0 00-.24 0l-.83.23-.89-2.16a2 2 0 00-1.75-1.17h-8.38a2 2 0 00-1.75 1.17l-.88 2.15-.83-.22a.67.67 0 00-.24 0 .73.73 0 00-.73.78v.46a1 1 0 00.95.95h.06l-.13.31a7 7 0 00-.45 2.26v4.31a1 1 0 00.95 1H298a1 1 0 00.95-1v-1.06h10.28v1.06a1 1 0 001 1h1.15a1 1 0 00.95-1v-4.31a7 7 0 00-.45-2.26l-.13-.31h.08a1 1 0 00.95-.95v-.46a.74.74 0 00-.78-.78zm-14.05 1.66l1.35-3.28a1.22 1.22 0 011-.71h7.52a1.23 1.23 0 011.05.71l1.34 3.28a.47.47 0 01-.47.7h-11.35a.47.47 0 01-.47-.7zm.6 4.71a1.23 1.23 0 111.22-1.23 1.23 1.23 0 01-1.25 1.23zm11.22 0a1.23 1.23 0 111.23-1.23 1.23 1.23 0 01-1.26 1.23z\" class=\"cls-2\" transform=\"translate(-287.81 -367.78)\"/>\n</svg>\n"
+          "svg": "<svg xmlns=\"http://www.w3.org/2000/svg\" id=\"Ebene_1\" data-name=\"Ebene 1\" viewBox=\"0 0 32.53 32.53\">  <defs>    <style>      .cls-2{fill:#fff}    </style>  </defs>  <path fill=\"#ff834a\" d=\"M320.34 384.05a16.27 16.27 0 11-16.26-16.27 16.26 16.26 0 0116.26 16.27\" transform=\"translate(-287.81 -367.78)\"/>  <path d=\"M304.35 370.35a4.7 4.7 0 11-3.3 8l.73-.76a3.5 3.5 0 002.57 1.08 3.56 3.56 0 002.59-1.07 3.62 3.62 0 000-5.16 3.55 3.55 0 00-2.59-1.06 3.64 3.64 0 00-3.65 3.64h1.57l-2.1 2.1-.05-.07-2-2h1.56a4.69 4.69 0 014.7-4.7zm-.51 2.62h.78v2.2l1.83 1.1-.39.64-2.22-1.35zM312 385.46a.67.67 0 00-.24 0l-.83.23-.89-2.16a2 2 0 00-1.75-1.17h-8.38a2 2 0 00-1.75 1.17l-.88 2.15-.83-.22a.67.67 0 00-.24 0 .73.73 0 00-.73.78v.46a1 1 0 00.95.95h.06l-.13.31a7 7 0 00-.45 2.26v4.31a1 1 0 00.95 1H298a1 1 0 00.95-1v-1.06h10.28v1.06a1 1 0 001 1h1.15a1 1 0 00.95-1v-4.31a7 7 0 00-.45-2.26l-.13-.31h.08a1 1 0 00.95-.95v-.46a.74.74 0 00-.78-.78zm-14.05 1.66l1.35-3.28a1.22 1.22 0 011-.71h7.52a1.23 1.23 0 011.05.71l1.34 3.28a.47.47 0 01-.47.7h-11.35a.47.47 0 01-.47-.7zm.6 4.71a1.23 1.23 0 111.22-1.23 1.23 1.23 0 01-1.25 1.23zm11.22 0a1.23 1.23 0 111.23-1.23 1.23 1.23 0 01-1.26 1.23z\" class=\"cls-2\" transform=\"translate(-287.81 -367.78)\"/></svg>"
         }
       },
       "geometry": {
@@ -219,9 +219,9 @@
         "name": "stadtmobil",
         "name_en": "stadtmobil",
         "name_de": "stadtmobil",
-        "address": "Stellpl\u00e4tze: 4",
-        "address_de": "Stellpl\u00e4tze: 4",
-        "address_en": "Capacity: 4",
+        "popupContent": "Stellpl\u00e4tze: 4",
+        "popupContent_de": "Stellpl\u00e4tze: 4",
+        "popupContent_en": "Capacity: 4",
         "icon": {
           "id": "carShareIcon"
         }
@@ -240,9 +240,9 @@
         "name": "Mariengarage Herrenberg",
         "name_en": "Mariengarage Herrenberg",
         "name_de": "Mariengarage Herrenberg",
-        "address": "Stellpl\u00e4tze: 1",
-        "address_de": "Stellpl\u00e4tze: 1",
-        "address_en": "Capacity: 1",
+        "popupContent": "Stellpl\u00e4tze: 1",
+        "popupContent_de": "Stellpl\u00e4tze: 1",
+        "popupContent_en": "Capacity: 1",
         "icon": {
           "id": "carShareIcon"
         }
@@ -261,9 +261,9 @@
         "name": "Bahnhof (Flugfeld-/Nordseite)",
         "name_en": "Bahnhof (Flugfeld-/Nordseite)",
         "name_de": "Bahnhof (Flugfeld-/Nordseite)",
-        "address": "Stellpl\u00e4tze: 1, Barrierefrei: ja",
-        "address_de": "Stellpl\u00e4tze: 1, Barrierefrei: ja",
-        "address_en": "Capacity: 1, Wheelchair: yes",
+        "popupContent": "Stellpl\u00e4tze: 1, Barrierefrei: ja",
+        "popupContent_de": "Stellpl\u00e4tze: 1, Barrierefrei: ja",
+        "popupContent_en": "Capacity: 1, Wheelchair: yes",
         "icon": {
           "id": "carShareIcon"
         }
@@ -282,9 +282,9 @@
         "name": "Hulb Bahnhof",
         "name_en": "Hulb Bahnhof",
         "name_de": "Hulb Bahnhof",
-        "address": "Stellpl\u00e4tze: 1, Barrierefrei: begrenzt",
-        "address_de": "Stellpl\u00e4tze: 1, Barrierefrei: begrenzt",
-        "address_en": "Capacity: 1, Wheelchair: limited",
+        "popupContent": "Stellpl\u00e4tze: 1, Barrierefrei: begrenzt",
+        "popupContent_de": "Stellpl\u00e4tze: 1, Barrierefrei: begrenzt",
+        "popupContent_en": "Capacity: 1, Wheelchair: limited",
         "icon": {
           "id": "carShareIcon"
         }
@@ -303,9 +303,9 @@
         "name": "teilAuto",
         "name_en": "teilAuto",
         "name_de": "teilAuto",
-        "address": "Stellpl\u00e4tze: 1, Telefon: +49 7071 1388335, Barrierefrei: ja",
-        "address_de": "Stellpl\u00e4tze: 1, Telefon: +49 7071 1388335, Barrierefrei: ja",
-        "address_en": "Capacity: 1, Phone: +49 7071 1388335, Wheelchair: yes",
+        "popupContent": "Stellpl\u00e4tze: 1, Telefon: +49 7071 1388335, Barrierefrei: ja",
+        "popupContent_de": "Stellpl\u00e4tze: 1, Telefon: +49 7071 1388335, Barrierefrei: ja",
+        "popupContent_en": "Capacity: 1, Phone: +49 7071 1388335, Wheelchair: yes",
         "icon": {
           "id": "carShareIcon"
         }
@@ -324,9 +324,9 @@
         "name_en": "Car sharing",
         "name_de": "Car-Sharing",
         "name": "Car-Sharing",
-        "address": "Stellpl\u00e4tze: 1",
-        "address_de": "Stellpl\u00e4tze: 1",
-        "address_en": "Capacity: 1",
+        "popupContent": "Stellpl\u00e4tze: 1",
+        "popupContent_de": "Stellpl\u00e4tze: 1",
+        "popupContent_en": "Capacity: 1",
         "icon": {
           "id": "carShareIcon"
         }
@@ -345,9 +345,9 @@
         "name": "G\u00e4rtringen",
         "name_en": "G\u00e4rtringen",
         "name_de": "G\u00e4rtringen",
-        "address": "Stellpl\u00e4tze: 1, Barrierefrei: ja",
-        "address_de": "Stellpl\u00e4tze: 1, Barrierefrei: ja",
-        "address_en": "Capacity: 1, Wheelchair: yes",
+        "popupContent": "Stellpl\u00e4tze: 1, Barrierefrei: ja",
+        "popupContent_de": "Stellpl\u00e4tze: 1, Barrierefrei: ja",
+        "popupContent_en": "Capacity: 1, Wheelchair: yes",
         "icon": {
           "id": "carShareIcon"
         }
@@ -366,12 +366,12 @@
         "name": "ebikestation",
         "name_en": "ebikestation",
         "name_de": "ebikestation",
-        "address": "Telefon: +49 30 69205046, Geb\u00fchrenpflichtig:: ja, Barrierefrei: ja",
-        "address_de": "Telefon: +49 30 69205046, Geb\u00fchrenpflichtig:: ja, Barrierefrei: ja",
-        "address_en": "Phone: +49 30 69205046, Fee: yes, Wheelchair: yes",
+        "popupContent": "Telefon: +49 30 69205046, Geb\u00fchrenpflichtig: ja, Barrierefrei: ja",
+        "popupContent_de": "Telefon: +49 30 69205046, Geb\u00fchrenpflichtig: ja, Barrierefrei: ja",
+        "popupContent_en": "Phone: +49 30 69205046, Fee: yes, Wheelchair: yes",
         "icon": {
           "id": "bikeRentIcon",
-          "svg": "<svg xmlns=\"http://www.w3.org/2000/svg\" id=\"Ebene_1\" data-name=\"Ebene 1\" viewBox=\"0 0 32.53 32.53\">\n  <defs>\n    <style>\n      .cls-2{fill:#fff}\n    </style>\n  </defs>\n  <path fill=\"#ff834a\" d=\"M313.29 384.05A16.27 16.27 0 11297 367.78a16.26 16.26 0 0116.26 16.27\" transform=\"translate(-280.76 -367.78)\"/>\n  <path d=\"M299.66 384.43a1.47 1.47 0 01-1.05-.44 1.38 1.38 0 01-.46-1 1.57 1.57 0 011.51-1.51 1.39 1.39 0 011 .46 1.47 1.47 0 01.44 1.05 1.43 1.43 0 01-.44 1 1.45 1.45 0 01-1 .44zm-7.87 4.88a3.59 3.59 0 012.65 1.09 3.65 3.65 0 011.07 2.67 3.66 3.66 0 01-3.72 3.73 3.69 3.69 0 01-2.67-1.07 3.57 3.57 0 01-1.09-2.66 3.63 3.63 0 011.09-2.67 3.67 3.67 0 012.67-1.09zm0 6.36a2.58 2.58 0 002.6-2.6 2.56 2.56 0 00-.76-1.86 2.44 2.44 0 00-1.84-.77 2.5 2.5 0 00-1.86.77 2.54 2.54 0 00-.78 1.86 2.49 2.49 0 00.78 1.85 2.56 2.56 0 001.86.75zm4.32-7.48l1.65 1.72v4.64h-1.47v-3.73l-2.43-2.1a1.19 1.19 0 01-.42-1.06 1.42 1.42 0 01.42-1.05l2.14-2.11a1.19 1.19 0 011.06-.42 1.86 1.86 0 011.19.42l1.44 1.44a3.64 3.64 0 002.67 1.12v1.51a5.14 5.14 0 01-3.79-1.58l-.6-.59zm6.15 1.12a3.72 3.72 0 013.76 3.76 3.57 3.57 0 01-1.09 2.66 3.66 3.66 0 01-2.67 1.07 3.66 3.66 0 01-3.72-3.73 3.65 3.65 0 011.07-2.67 3.59 3.59 0 012.65-1.09zm0 6.36a2.56 2.56 0 001.86-.75 2.49 2.49 0 00.78-1.85 2.54 2.54 0 00-.78-1.86 2.5 2.5 0 00-1.86-.77 2.45 2.45 0 00-1.84.77 2.56 2.56 0 00-.76 1.86 2.58 2.58 0 002.6 2.6zM297.3 370.35a4.7 4.7 0 11-3.31 8l.74-.76a3.5 3.5 0 002.57 1.08 3.56 3.56 0 002.59-1.07 3.62 3.62 0 000-5.16 3.55 3.55 0 00-2.59-1.06 3.64 3.64 0 00-3.65 3.64h1.57l-2.11 2.1v-.07l-2-2h1.57a4.69 4.69 0 014.7-4.7zm-.52 2.62h.79v2.2l1.83 1.1-.39.64-2.23-1.35z\" class=\"cls-2\" transform=\"translate(-280.76 -367.78)\"/>\n</svg>"
+          "svg": "<svg xmlns=\"http://www.w3.org/2000/svg\" id=\"Ebene_1\" data-name=\"Ebene 1\" viewBox=\"0 0 32.53 32.53\">  <defs>    <style>      .cls-2{fill:#fff}    </style>  </defs>  <path fill=\"#ff834a\" d=\"M313.29 384.05A16.27 16.27 0 11297 367.78a16.26 16.26 0 0116.26 16.27\" transform=\"translate(-280.76 -367.78)\"/>  <path d=\"M299.66 384.43a1.47 1.47 0 01-1.05-.44 1.38 1.38 0 01-.46-1 1.57 1.57 0 011.51-1.51 1.39 1.39 0 011 .46 1.47 1.47 0 01.44 1.05 1.43 1.43 0 01-.44 1 1.45 1.45 0 01-1 .44zm-7.87 4.88a3.59 3.59 0 012.65 1.09 3.65 3.65 0 011.07 2.67 3.66 3.66 0 01-3.72 3.73 3.69 3.69 0 01-2.67-1.07 3.57 3.57 0 01-1.09-2.66 3.63 3.63 0 011.09-2.67 3.67 3.67 0 012.67-1.09zm0 6.36a2.58 2.58 0 002.6-2.6 2.56 2.56 0 00-.76-1.86 2.44 2.44 0 00-1.84-.77 2.5 2.5 0 00-1.86.77 2.54 2.54 0 00-.78 1.86 2.49 2.49 0 00.78 1.85 2.56 2.56 0 001.86.75zm4.32-7.48l1.65 1.72v4.64h-1.47v-3.73l-2.43-2.1a1.19 1.19 0 01-.42-1.06 1.42 1.42 0 01.42-1.05l2.14-2.11a1.19 1.19 0 011.06-.42 1.86 1.86 0 011.19.42l1.44 1.44a3.64 3.64 0 002.67 1.12v1.51a5.14 5.14 0 01-3.79-1.58l-.6-.59zm6.15 1.12a3.72 3.72 0 013.76 3.76 3.57 3.57 0 01-1.09 2.66 3.66 3.66 0 01-2.67 1.07 3.66 3.66 0 01-3.72-3.73 3.65 3.65 0 011.07-2.67 3.59 3.59 0 012.65-1.09zm0 6.36a2.56 2.56 0 001.86-.75 2.49 2.49 0 00.78-1.85 2.54 2.54 0 00-.78-1.86 2.5 2.5 0 00-1.86-.77 2.45 2.45 0 00-1.84.77 2.56 2.56 0 00-.76 1.86 2.58 2.58 0 002.6 2.6zM297.3 370.35a4.7 4.7 0 11-3.31 8l.74-.76a3.5 3.5 0 002.57 1.08 3.56 3.56 0 002.59-1.07 3.62 3.62 0 000-5.16 3.55 3.55 0 00-2.59-1.06 3.64 3.64 0 00-3.65 3.64h1.57l-2.11 2.1v-.07l-2-2h1.57a4.69 4.69 0 014.7-4.7zm-.52 2.62h.79v2.2l1.83 1.1-.39.64-2.23-1.35z\" class=\"cls-2\" transform=\"translate(-280.76 -367.78)\"/></svg>"
         }
       },
       "geometry": {
@@ -388,9 +388,9 @@
         "name": "Bahnhof B\u00f6blingen/Talstra\u00dfe",
         "name_en": "Bahnhof B\u00f6blingen/Talstra\u00dfe",
         "name_de": "Bahnhof B\u00f6blingen/Talstra\u00dfe",
-        "address": "Stellpl\u00e4tze: 12",
-        "address_de": "Stellpl\u00e4tze: 12",
-        "address_en": "Capacity: 12",
+        "popupContent": "Stellpl\u00e4tze: 12",
+        "popupContent_de": "Stellpl\u00e4tze: 12",
+        "popupContent_en": "Capacity: 12",
         "icon": {
           "id": "bikeRentIcon"
         }
@@ -409,9 +409,9 @@
         "name": "ebikestation",
         "name_en": "ebikestation",
         "name_de": "ebikestation",
-        "address": "Stellpl\u00e4tze: 10, Barrierefrei: begrenzt",
-        "address_de": "Stellpl\u00e4tze: 10, Barrierefrei: begrenzt",
-        "address_en": "Capacity: 10, Wheelchair: limited",
+        "popupContent": "Stellpl\u00e4tze: 10, Barrierefrei: begrenzt",
+        "popupContent_de": "Stellpl\u00e4tze: 10, Barrierefrei: begrenzt",
+        "popupContent_en": "Capacity: 10, Wheelchair: limited",
         "icon": {
           "id": "bikeRentIcon"
         }
@@ -430,9 +430,9 @@
         "name_en": "Bike rental",
         "name_de": "Fahrradverleih",
         "name": "Fahrradverleih",
-        "address": "",
-        "address_de": "",
-        "address_en": "",
+        "popupContent": "",
+        "popupContent_de": "",
+        "popupContent_en": "",
         "icon": {
           "id": "bikeRentIcon"
         }
@@ -451,9 +451,9 @@
         "name": "Bahnhof Goldberg/Leipziger Stra\u00dfe",
         "name_en": "Bahnhof Goldberg/Leipziger Stra\u00dfe",
         "name_de": "Bahnhof Goldberg/Leipziger Stra\u00dfe",
-        "address": "Stellpl\u00e4tze: 6",
-        "address_de": "Stellpl\u00e4tze: 6",
-        "address_en": "Capacity: 6",
+        "popupContent": "Stellpl\u00e4tze: 6",
+        "popupContent_de": "Stellpl\u00e4tze: 6",
+        "popupContent_en": "Capacity: 6",
         "icon": {
           "id": "bikeRentIcon"
         }
@@ -472,9 +472,9 @@
         "name_en": "Bike rental",
         "name_de": "Fahrradverleih",
         "name": "Fahrradverleih",
-        "address": "Stellpl\u00e4tze: 6",
-        "address_de": "Stellpl\u00e4tze: 6",
-        "address_en": "Capacity: 6",
+        "popupContent": "Stellpl\u00e4tze: 6",
+        "popupContent_de": "Stellpl\u00e4tze: 6",
+        "popupContent_en": "Capacity: 6",
         "icon": {
           "id": "bikeRentIcon"
         }
@@ -493,9 +493,9 @@
         "name_en": "Bike rental",
         "name_de": "Fahrradverleih",
         "name": "Fahrradverleih",
-        "address": "",
-        "address_de": "",
-        "address_en": "",
+        "popupContent": "",
+        "popupContent_de": "",
+        "popupContent_en": "",
         "icon": {
           "id": "bikeRentIcon"
         }


### PR DESCRIPTION
## Proposed Changes
There were an issue going on with route planning from/to GeoJson layer locations. The `address` property was used to display additional data, which then appeared as if it *was* an address.
![Screenshot_2020-05-27_10-09-00](https://user-images.githubusercontent.com/46535522/82997372-93e92700-a006-11ea-805f-ad6f882b67cc.png)
So I changed the property name of the additional data from `address` to `popupContent`. (This change will occur also in the overpass-layers repo.)

This way `address` became undefined, which also had some unwanted side effects:
![Screenshot_2020-05-27_09-47-41](https://user-images.githubusercontent.com/46535522/82997243-6a300000-a006-11ea-9c56-aa3852412053.png)
![Screenshot_2020-05-27_10-01-32](https://user-images.githubusercontent.com/46535522/82997248-6ac89680-a006-11ea-8fbe-65397b409f0d.png)

I set the default value of `address` equal to the `header`, which now seems to be a bit more usable:
![Screenshot_2020-05-27_10-00-46](https://user-images.githubusercontent.com/46535522/82997212-5edcd480-a006-11ea-9ede-6e889c70cc8e.png)
(This last step needed some additional changes to the `description` value in order to not to duplicate the `name` of the location in the popup.)

Otherwise the display of the popups did not change:
![Screenshot_2020-05-27_10-47-12](https://user-images.githubusercontent.com/46535522/82998001-6fda1580-a007-11ea-9b54-d26ceee01ceb.png)

