### PR TITLE
Draw icon to indicate another vehicle

### DIFF
--- a/app/component/RouteStop.js
+++ b/app/component/RouteStop.js
@@ -18,6 +18,7 @@ import { AlertSeverityLevelType, RealtimeStateType } from '../constants';
 import { getActiveAlertSeverityLevel } from '../util/alertUtils';
 import { PREFIX_STOPS } from '../util/path';
 import { addAnalyticsEvent } from '../util/analyticsUtils';
+import IconWithTail from './IconWithTail';
 
 const exampleStop = {
   stopTimesForPattern: [
@@ -56,6 +57,7 @@ class RouteStop extends React.PureComponent {
     first: PropTypes.bool,
     last: PropTypes.bool,
     displayNextDeparture: PropTypes.bool,
+    prevVehicleDeparture: PropTypes.number,
   };
 
   static defaultProps = {
@@ -63,6 +65,7 @@ class RouteStop extends React.PureComponent {
     className: '',
     first: false,
     last: false,
+    prevVehicleDeparture: null,
   };
 
   static description = () => (
@@ -142,9 +145,24 @@ class RouteStop extends React.PureComponent {
       stop,
       vehicle,
       displayNextDeparture,
+      prevVehicleDeparture,
     } = this.props;
     const patternExists =
       stop.stopTimesForPattern && stop.stopTimesForPattern.length > 0;
+
+    /* If vehicle is null, draw a simple image to indicate the different vehicle. */
+    const vehicleIcon = !vehicle &&
+      prevVehicleDeparture &&
+      patternExists &&
+      prevVehicleDeparture > stop.stopTimesForPattern[0].scheduledDeparture && (
+        <span className="route-now-content">
+          <IconWithTail
+            className={cx(mode, 'tail-icon')}
+            img={`icon-icon_${mode}-live`}
+            rotate={180}
+          />
+        </span>
+      );
 
     const vehicleTripLink = vehicle && (
       <Relay.RootContainer
@@ -181,7 +199,10 @@ class RouteStop extends React.PureComponent {
           this.element = el;
         }}
       >
-        <div className="route-stop-now">{vehicleTripLink}</div>
+        <div className="route-stop-now">
+          {vehicleTripLink}
+          {vehicleIcon}
+        </div>
         <div className={cx('route-stop-now_circleline', mode)}>
           <svg
             xmlns="http://www.w3.org/2000/svg"

--- a/app/component/RouteStopListContainer.js
+++ b/app/component/RouteStopListContainer.js
@@ -77,6 +77,8 @@ class RouteStopListContainer extends React.PureComponent {
           nearest.distance <
             this.context.config.nearestStopDistance.maxShownDistance &&
           nearest.stop.gtfsId) === stop.gtfsId;
+      const prevStopPattern =
+        i > 0 ? stops[i - 1].stopTimesForPattern[0] : null;
 
       return (
         <RouteStop
@@ -96,6 +98,9 @@ class RouteStopListContainer extends React.PureComponent {
           first={i === 0}
           className={rowClassName}
           displayNextDeparture={this.context.config.displayNextDeparture}
+          prevVehicleDeparture={
+            prevStopPattern ? prevStopPattern.scheduledDeparture : null
+          }
         />
       );
     });


### PR DESCRIPTION
## Proposed Changes
Since we don't have the required data for the vehicle positions, I introduced a new prop `prevVehicleDeparture` which can be compared with the actual departure time. If the "next" is earlier than the "previous", we know that that is another vehicle, so we should indicate this with the icon.

## Review
  - Read and verify the code changes
  - Test the functionality by running the UI locally with all popular browsers available in your platform
  - Merge the pull request

Closes #229 