### PR TITLE
solve broken deep links iOS

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -2816,7 +2816,7 @@ ajv@6.10.2:
     json-schema-traverse "^0.4.1"
     uri-js "^4.2.2"
 
-ajv@^6.1.0, ajv@^6.10.2, ajv@^6.12.2, ajv@^6.5.3, ajv@^6.5.5:
+ajv@^6.1.0, ajv@^6.10.2, ajv@^6.12.2, ajv@^6.5.3, ajv@^6.5.5, ajv@^6.6.2:
   version "6.12.2"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.12.2.tgz#c629c5eced17baf314437918d2da88c99d5958cd"
   integrity sha512-k+V+hzjm5q/Mr8ef/1Y9goCmlsK4I6Sm74teeyGvFk1XrOsbsKLjEdrvny42CZ+a8sXbk8KWpY/bDwS+FLL2UQ==


### PR DESCRIPTION
## Proposed Changes

  - it looks like `yarn install` solved the problem
  - I've been testing it for an hour and could NOT reproduce the bug
  - `@ajv`, that was updated, is a json validator, more info [here](https://www.npmjs.com/package/ajv)

## Review

  - Read and verify the code changes
  - Test the functionality by running the UI locally with all popular browsers available in your platform

closes #244 