### PR TITLE
enabled redirectReittiopasParams

### DIFF
--- a/app/configurations/config.hb.js
+++ b/app/configurations/config.hb.js
@@ -289,7 +289,7 @@ export default configMerger(walttiConfig, {
     ],
   },
 
-  redirectReittiopasParams: false,
+  redirectReittiopasParams: true,
 
   themeMap: {
     hb: 'hb',


### PR DESCRIPTION
## Proposed Changes

  - enabled and tested `redirectReittiopasParams` feature
  - `from` **or** `to` and `from to`(itinerary) queries worked fine
  - if you search for a general POI like `bank` you may not get the desired POI, I tried to set coordinates too but it was ignored in every way I tried

## Review

  - Read and verify the code changes
  - Test the functionality by running the UI locally with all popular browsers available in your platform

closes #257  