### PR TITLE
Display citybike station link

### DIFF
--- a/app/component/BicycleLeg.js
+++ b/app/component/BicycleLeg.js
@@ -15,6 +15,7 @@ import {
   getCityBikeNetworkConfig,
   getCityBikeNetworkId,
   CityBikeNetworkType,
+  getCityBikeUrl,
 } from '../util/citybikes';
 import { isKeyboardSelectionEvent } from '../util/browser';
 import ServiceAlertIcon from './ServiceAlertIcon';
@@ -64,10 +65,14 @@ function BicycleLeg({ focusAction, index, leg }, { config }) {
 
   let networkIcon;
   let hasAlert = false;
+  let rentalUri;
 
   if (leg.rentedBike === true) {
     hasAlert = leg.alerts && leg.alerts.length > 0 && leg.alerts[0].alertUrl;
     networkIcon = networkConfig && getCityBikeNetworkIcon(networkConfig);
+    rentalUri =
+      leg.from.bikeRentalStation.rentalUriWeb ||
+      getCityBikeUrl(leg.from.bikeRentalStation.networks, 'de', config);
 
     modeClassName = 'citybike';
     legDescription = (
@@ -145,6 +150,18 @@ function BicycleLeg({ focusAction, index, leg }, { config }) {
               />
               <FormattedMessage id={leg.alerts[0].alertUrl} />
             </div>
+          )}
+          {rentalUri && (
+            <a
+              href={rentalUri}
+              rel="noopener noreferrer"
+              className="citybike-website-btn"
+              target="_blank"
+            >
+              <button className="standalone-btn cursor-pointer">
+                <FormattedMessage id="use-citybike" />
+              </button>
+            </a>
           )}
         </div>
       </div>

--- a/app/component/CityBikeContent.js
+++ b/app/component/CityBikeContent.js
@@ -36,7 +36,10 @@ const CityBikeContent = ({ station, lang }, { config }) => (
     {config.transportModes.citybike.availableForSelection &&
       getCityBikeUrl(station.networks, lang, config) && (
         <CityBikeUse
-          url={getCityBikeUrl(station.networks, lang, config)}
+          url={
+            station.rentalUriWeb ||
+            getCityBikeUrl(station.networks, lang, config)
+          }
           type={getCityBikeType(station.networks, config)}
         />
       )}

--- a/app/component/CityBikeContent.js
+++ b/app/component/CityBikeContent.js
@@ -34,7 +34,8 @@ const CityBikeContent = ({ station, lang }, { config }) => (
         />
       )}
     {config.transportModes.citybike.availableForSelection &&
-      getCityBikeUrl(station.networks, lang, config) && (
+      (station.rentalUriWeb ||
+        getCityBikeUrl(station.networks, lang, config)) && (
         <CityBikeUse
           url={
             station.rentalUriWeb ||

--- a/app/component/itinerary.scss
+++ b/app/component/itinerary.scss
@@ -721,6 +721,17 @@ $itinerary-tab-switch-height: 48px;
   }
 }
 
+.citybike-website-btn {
+  text-decoration: none;
+  button {
+    background-color: $citybike-color !important;
+    display: block;
+    margin-left: auto;
+    margin-right: auto;
+    margin-top: 10px;
+  }
+}
+
 .bp-large .row.itinerary-row .itinerary-instruction-column:not(.to)::after {
   left: 3px;
 }

--- a/app/component/map/non-tile-layer/CityBikeMarker.js
+++ b/app/component/map/non-tile-layer/CityBikeMarker.js
@@ -137,6 +137,7 @@ export default Relay.createContainer(CityBikeMarker, {
         stationId
         networks
         bikesAvailable
+        rentalUriWeb
       }
     `,
   },

--- a/app/component/map/popups/CityBikePopup.js
+++ b/app/component/map/popups/CityBikePopup.js
@@ -65,6 +65,7 @@ export default Relay.createContainer(CityBikePopup, {
         spacesAvailable
         state
         networks
+        rentalUriWeb
       }
     `,
   },

--- a/app/configurations/config.hb.js
+++ b/app/configurations/config.hb.js
@@ -126,6 +126,18 @@ export default configMerger(walttiConfig, {
           en: 'https://www.regioradstuttgart.de/',
         },
       },
+      "uri-demo": {
+        icon: 'regiorad',
+        name: {
+          de: 'RegioRad',
+          en: 'RegioRad',
+        },
+        type: 'citybike',
+        url: {
+          de: 'https://www.regioradstuttgart.de/de',
+          en: 'https://www.regioradstuttgart.de/',
+        },
+      },
       taxi: {
         icon: 'taxi',
         name: {
@@ -142,6 +154,7 @@ export default configMerger(walttiConfig, {
         },
         type: 'car-sharing',
       },
+
     }
   },
 

--- a/app/configurations/config.hb.js
+++ b/app/configurations/config.hb.js
@@ -126,18 +126,6 @@ export default configMerger(walttiConfig, {
           en: 'https://www.regioradstuttgart.de/',
         },
       },
-      "uri-demo": {
-        icon: 'regiorad',
-        name: {
-          de: 'RegioRad',
-          en: 'RegioRad',
-        },
-        type: 'citybike',
-        url: {
-          de: 'https://www.regioradstuttgart.de/de',
-          en: 'https://www.regioradstuttgart.de/',
-        },
-      },
       taxi: {
         icon: 'taxi',
         name: {
@@ -154,7 +142,6 @@ export default configMerger(walttiConfig, {
         },
         type: 'car-sharing',
       },
-
     }
   },
 

--- a/app/translations/de.json
+++ b/app/translations/de.json
@@ -592,7 +592,7 @@
   "try-again": "Nochmal versuchen",
   "tuesday": "Dienstags",
   "unpreferred": "Routen vermeiden",
-  "use-citybike": "Leihrad benutzen",
+  "use-citybike": "Leihrad buchen",
   "use-national-service": "Sie können auch das überregionale Angebot benutzen: ",
   "use-own-position": "Aktuellen Standort benutzen",
   "using-modes": "Verkehrsmittel",

--- a/app/translations/en.json
+++ b/app/translations/en.json
@@ -583,7 +583,7 @@
   "try-again": "Try again",
   "tuesday": "Tuesdays",
   "unpreferred": "Avoid routes",
-  "use-citybike": "Start using Bike-Sharing",
+  "use-citybike": "Rent bicycle",
   "use-national-service": "You can also try the national service available at",
   "use-own-position": "Use current location",
   "using-modes": "I want to travel by",

--- a/build/schema.json
+++ b/build/schema.json
@@ -5979,6 +5979,22 @@
                         },
                         "isDeprecated": false,
                         "deprecationReason": null
+                    },
+                    {
+                        "name": "rentalUriWeb",
+                        "description": "Unique URI",
+                        "args": [],
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "SCALAR",
+                                "name": "String",
+                                "ofType": null
+                            }
+                        },
+                        "isDeprecated": false,
+                        "deprecationReason": null
                     }
                 ],
                 "inputFields": null,


### PR DESCRIPTION
## Proposed Changes
  - added `rentalUriWeb` to graphQL schema and queries
  - use `rentalUriWeb` if exists as link url in the citybike popups
  - display button to `rentalUriWeb` or network url at the itinerary details
    ![Screenshot_2020-07-08_12-18-17](https://user-images.githubusercontent.com/46535522/86907326-222bef00-c115-11ea-89f4-58220d349e4a.png)

## Review
  - Read and verify the code changes
  - Test the functionality by running the UI locally with all popular browsers available in your platform

closes #271