### PR TITLE
Shrink legs in summary row

### DIFF
--- a/app/component/departure.scss
+++ b/app/component/departure.scss
@@ -182,7 +182,7 @@
   vertical-align: top;
   position: relative;
   display: inline-block;
-  min-width: 64px;
+  // min-width: 64px; // would prevent shrinking in SummaryRow
   &.vertical {
     max-width: 100%;
     .vehicle-number {


### PR DESCRIPTION
## Proposed Changes
Seems like there were a `min-width` property set to each leg, this is why the flexbox couldn't shrink it below a level. I commented out that line.
![image](https://user-images.githubusercontent.com/46535522/88368077-8e515880-cd8d-11ea-8706-b3dc2fe43c66.png)

## Review
  - Read and verify the code changes
  - Test the functionality by running the UI locally with all popular browsers available in your platform

closes #275 