### PR TITLE
Add switch for 'search stops and lines' field of index page

### DIFF
--- a/app/component/IndexPage.js
+++ b/app/component/IndexPage.js
@@ -234,28 +234,34 @@ class IndexPage extends React.Component {
                 />
               </div>
             ) : (
-              <div className="stops-near-you-text">
-                <h2>
-                  {' '}
-                  {intl.formatMessage({
-                    id: 'stop-near-you-title',
-                    defaultMessage: 'Stops and lines near you',
-                  })}
-                </h2>
-              </div>
+              config.showStopAndRouteSearch && (
+                <div className="stops-near-you-text">
+                  <h2>
+                    {' '}
+                    {intl.formatMessage({
+                      id: 'stop-near-you-title',
+                      defaultMessage: 'Stops and lines near you',
+                    })}
+                  </h2>
+                </div>
+              )
             )}
-            <DTAutoSuggestWithSearchContext
-              appElement="#app"
-              icon="search"
-              id="stop-route-station"
-              refPoint={origin}
-              className="destination"
-              placeholder="stop-near-you"
-              value=""
-              sources={stopAndRouteSearchSources}
-              targets={stopAndRouteSearchTargets}
-            />
-            <CtrlPanel.SeparatorLine />
+            {config.showStopAndRouteSearch && (
+              <>
+                <DTAutoSuggestWithSearchContext
+                  appElement="#app"
+                  icon="search"
+                  id="stop-route-station"
+                  refPoint={origin}
+                  className="destination"
+                  placeholder="stop-near-you"
+                  value=""
+                  sources={stopAndRouteSearchSources}
+                  targets={stopAndRouteSearchTargets}
+                />
+                <CtrlPanel.SeparatorLine />
+              </>
+            )}
             {!trafficNowLink ||
               (trafficNowLink[lang] !== '' && (
                 <TrafficNowLink
@@ -330,29 +336,35 @@ class IndexPage extends React.Component {
                 />
               </div>
             ) : (
-              <div className="stops-near-you-text">
-                <h2>
-                  {' '}
-                  {intl.formatMessage({
-                    id: 'stop-near-you-title',
-                    defaultMessage: 'Stops and lines near you',
-                  })}
-                </h2>
-              </div>
+              config.showStopAndRouteSearch && (
+                <div className="stops-near-you-text">
+                  <h2>
+                    {' '}
+                    {intl.formatMessage({
+                      id: 'stop-near-you-title',
+                      defaultMessage: 'Stops and lines near you',
+                    })}
+                  </h2>
+                </div>
+              )
             )}
-            <DTAutoSuggestWithSearchContext
-              appElement="#app"
-              icon="search"
-              id="stop-route-station"
-              refPoint={origin}
-              className="destination"
-              placeholder="stop-near-you"
-              value=""
-              sources={stopAndRouteSearchSources}
-              targets={stopAndRouteSearchTargets}
-              isMobile
-            />
-            <CtrlPanel.SeparatorLine />
+            {config.showStopAndRouteSearch && (
+              <>
+                <DTAutoSuggestWithSearchContext
+                  appElement="#app"
+                  icon="search"
+                  id="stop-route-station"
+                  refPoint={origin}
+                  className="destination"
+                  placeholder="stop-near-you"
+                  value=""
+                  sources={stopAndRouteSearchSources}
+                  targets={stopAndRouteSearchTargets}
+                  isMobile
+                />
+                <CtrlPanel.SeparatorLine />
+              </>
+            )}
             {!trafficNowLink ||
               (trafficNowLink[lang] !== '' && (
                 <TrafficNowLink

--- a/app/configurations/config.default.js
+++ b/app/configurations/config.default.js
@@ -788,6 +788,7 @@ export default {
 
   showNearYouButtons: false,
   nearYouModes: [],
+  showStopAndRouteSearch: true,
 
   zoneIconsAsSvg: false,
 };

--- a/app/configurations/config.hbnext.js
+++ b/app/configurations/config.hbnext.js
@@ -456,4 +456,5 @@ export default configMerger(walttiConfig, {
     showVehiclesOnSummaryPage: true,
     showBikeAndPublicItineraries: true,
     showBikeAndParkItineraries: true,
+    showStopAndRouteSearch: false,
 });


### PR DESCRIPTION
## Proposed Changes
Removed the search field from the index page by adding a config switch `showStopAndRouteSearch`. This is true by default and set to false in `config.hb`. 

![image](https://user-images.githubusercontent.com/46535522/99670112-4eb32880-2a70-11eb-8c40-f70ca0b1c7dc.png)

## Review
  - Read and verify the code changes
  - Test the functionality by running the UI locally with all popular browsers available in your platform

Closes #299