### PR TITLE
Add vehicle indicator image to route page

### DIFF
--- a/app/component/RouteStop.js
+++ b/app/component/RouteStop.js
@@ -15,6 +15,7 @@ import { AlertSeverityLevelType, RealtimeStateType } from '../constants';
 import { getActiveAlertSeverityLevel } from '../util/alertUtils';
 import { PREFIX_STOPS } from '../util/path';
 import { addAnalyticsEvent } from '../util/analyticsUtils';
+import IconWithTail from './IconWithTail';
 
 const exampleStop = {
   stopTimesForPattern: [
@@ -51,6 +52,14 @@ class RouteStop extends React.PureComponent {
     distance: PropTypes.number,
     currentTime: PropTypes.number.isRequired,
     last: PropTypes.bool,
+    prevVehicleDeparture: PropTypes.number,
+    patternId: PropTypes.string.isRequired,
+  };
+
+  static defaultProps = {
+    className: '',
+    last: false,
+    prevVehicleDeparture: null,
   };
 
   static description = () => (
@@ -129,9 +138,26 @@ class RouteStop extends React.PureComponent {
       mode,
       stop,
       vehicle,
+      prevVehicleDeparture,
+      patternId,
     } = this.props;
     const patternExists =
       stop.stopTimesForPattern && stop.stopTimesForPattern.length > 0;
+
+    /* If vehicle is null, draw a simple image to indicate the different vehicle. */
+    const vehicleIcon = !vehicle &&
+      prevVehicleDeparture &&
+      patternExists &&
+      prevVehicleDeparture > stop.stopTimesForPattern[0].scheduledDeparture && (
+        <span className="route-now-content">
+          <IconWithTail
+            className={cx(mode, 'tail-icon')}
+            img={`icon-icon_${mode}-live`}
+            rotate={180}
+            vehicleNumber={patternId}
+          />
+        </span>
+      );
 
     let vehicleTripLink;
 
@@ -150,7 +176,10 @@ class RouteStop extends React.PureComponent {
           this.element = el;
         }}
       >
-        <div className="route-stop-now">{vehicleTripLink}</div>
+        <div className="route-stop-now">
+          {vehicleTripLink}
+          {vehicleIcon}
+        </div>
         <div className={cx('route-stop-now_circleline', mode)}>
           <svg
             xmlns="http://www.w3.org/2000/svg"

--- a/app/component/RouteStopListContainer.js
+++ b/app/component/RouteStopListContainer.js
@@ -14,6 +14,7 @@ import withBreakpoint from '../util/withBreakpoint';
 class RouteStopListContainer extends React.PureComponent {
   static propTypes = {
     pattern: PropTypes.object.isRequired,
+    patternId: PropTypes.string.isRequired,
     className: PropTypes.string,
     vehicles: PropTypes.object,
     position: PropTypes.object.isRequired,
@@ -65,6 +66,8 @@ class RouteStopListContainer extends React.PureComponent {
           nearest.distance <
             this.context.config.nearestStopDistance.maxShownDistance &&
           nearest.stop.gtfsId) === stop.gtfsId;
+      const prevStopPattern =
+        i > 0 ? stops[i - 1].stopTimesForPattern[0] : null;
 
       return (
         <RouteStop
@@ -83,6 +86,10 @@ class RouteStopListContainer extends React.PureComponent {
           last={i === stops.length - 1}
           first={i === 0}
           className={rowClassName}
+          prevVehicleDeparture={
+            prevStopPattern ? prevStopPattern.scheduledDeparture : null
+          }
+          patternId={this.props.patternId.split('-')[1]}
         />
       );
     });


### PR DESCRIPTION
## Proposed Changes
Since we do not have `vehicle` data, we need to add the indicator images in a tricky way for the next UI based on #233. HSL switched from icons to vehicle number display, so I had to pass the `patternId` too so the indicator is not an empty circle.
![image](https://user-images.githubusercontent.com/46535522/99787912-a6a96800-2b20-11eb-9116-a6b697fb3724.png)

## Review
  - Read and verify the code changes
  - Test the functionality by running the UI locally with all popular browsers available in your platform

Closes #301