### PR TITLE
Use triangle factors when bike is enabled

### DIFF
--- a/app/component/SummaryPage.js
+++ b/app/component/SummaryPage.js
@@ -556,6 +556,7 @@ class SummaryPage extends React.Component {
         $transferPenalty: Int
         $bikeSpeed: Float
         $optimize: OptimizeType
+        $triangle: InputTriangle
         $itineraryFiltering: Float
         $unpreferred: InputUnpreferred
         $locale: String
@@ -611,6 +612,7 @@ class SummaryPage extends React.Component {
           arriveBy: $arriveBy
           bikeSpeed: $bikeSpeed
           optimize: $optimize
+          triangle: $triangle
           locale: $locale
         ) @include(if: $shouldMakeBikeQuery) {
           ...SummaryPlanContainer_plan
@@ -651,6 +653,7 @@ class SummaryPage extends React.Component {
           transferPenalty: $transferPenalty
           bikeSpeed: $bikeSpeed
           optimize: $optimize
+          triangle: $triangle
           itineraryFiltering: $itineraryFiltering
           unpreferred: $unpreferred
           locale: $locale
@@ -707,6 +710,7 @@ class SummaryPage extends React.Component {
           transferPenalty: $transferPenalty
           bikeSpeed: $bikeSpeed
           optimize: $optimize
+          triangle: $triangle
           itineraryFiltering: $itineraryFiltering
           unpreferred: $unpreferred
           locale: $locale
@@ -768,6 +772,7 @@ class SummaryPage extends React.Component {
           transferPenalty: $transferPenalty
           bikeSpeed: $bikeSpeed
           optimize: $optimize
+          triangle: $triangle
           itineraryFiltering: $itineraryFiltering
           unpreferred: $unpreferred
           locale: $locale
@@ -834,6 +839,7 @@ class SummaryPage extends React.Component {
           transferPenalty: $transferPenalty
           bikeSpeed: $bikeSpeed
           optimize: $optimize
+          triangle: $triangle
           itineraryFiltering: $itineraryFiltering
           unpreferred: $unpreferred
           locale: $locale
@@ -2739,6 +2745,7 @@ const containerComponent = createRefetchContainer(
         transferPenalty: { type: "Int" }
         bikeSpeed: { type: "Float" }
         optimize: { type: "OptimizeType" }
+        triangle: { type: "InputTriangle" }
         itineraryFiltering: { type: "Float" }
         unpreferred: { type: "InputUnpreferred" }
         allowedBikeRentalNetworks: { type: "[String]" }
@@ -2766,6 +2773,7 @@ const containerComponent = createRefetchContainer(
           transferPenalty: $transferPenalty
           bikeSpeed: $bikeSpeed
           optimize: $optimize
+          triangle: $triangle
           itineraryFiltering: $itineraryFiltering
           unpreferred: $unpreferred
           allowedBikeRentalNetworks: $allowedBikeRentalNetworks

--- a/app/component/SummaryPage.js
+++ b/app/component/SummaryPage.js
@@ -1088,6 +1088,7 @@ class SummaryPage extends React.Component {
         $transferPenalty: Int
         $bikeSpeed: Float
         $optimize: OptimizeType
+        $triangle: InputTriangle
         $itineraryFiltering: Float
         $unpreferred: InputUnpreferred
         $allowedBikeRentalNetworks: [String]
@@ -1113,6 +1114,7 @@ class SummaryPage extends React.Component {
           transferPenalty: $transferPenalty
           bikeSpeed: $bikeSpeed
           optimize: $optimize
+          triangle: $triangle
           itineraryFiltering: $itineraryFiltering
           unpreferred: $unpreferred
           allowedBikeRentalNetworks: $allowedBikeRentalNetworks
@@ -1284,6 +1286,7 @@ class SummaryPage extends React.Component {
         $transferPenalty: Int
         $bikeSpeed: Float
         $optimize: OptimizeType
+        $triangle: InputTriangle
         $itineraryFiltering: Float
         $unpreferred: InputUnpreferred
         $allowedBikeRentalNetworks: [String]
@@ -1309,6 +1312,7 @@ class SummaryPage extends React.Component {
           transferPenalty: $transferPenalty
           bikeSpeed: $bikeSpeed
           optimize: $optimize
+          triangle: $triangle
           itineraryFiltering: $itineraryFiltering
           unpreferred: $unpreferred
           allowedBikeRentalNetworks: $allowedBikeRentalNetworks

--- a/app/configurations/config.hbnext.js
+++ b/app/configurations/config.hbnext.js
@@ -56,6 +56,10 @@ export default configMerger(walttiConfig, {
     optimize: "QUICK",
 
     defaultSettings: {
+        optimize: "TRIANGLE",
+        safetyFactor: 0.4,
+        slopeFactor: 0.3,
+        timeFactor: 0.3,
     },
 
     itinerary: {

--- a/app/util/planParamUtil.js
+++ b/app/util/planParamUtil.js
@@ -245,7 +245,14 @@ export const preparePlanParams = config => (
         wheelchair,
         transferPenalty: config.transferPenalty,
         bikeSpeed: settings.bikeSpeed,
-        optimize: config.optimize,
+        optimize: settings.includeBikeSuggestions
+          ? config.defaultSettings.optimize
+          : config.optimize,
+        triangle: {
+          safetyFactor: config.defaultSettings.safetyFactor,
+          slopeFactor: config.defaultSettings.slopeFactor,
+          timeFactor: config.defaultSettings.timeFactor,
+        },
         itineraryFiltering: config.itineraryFiltering,
         unpreferred: {
           useUnpreferredRoutesPenalty: config.useUnpreferredRoutesPenalty,

--- a/app/util/queryUtils.js
+++ b/app/util/queryUtils.js
@@ -173,6 +173,7 @@ export const planQuery = graphql`
     $transferPenalty: Int
     $bikeSpeed: Float
     $optimize: OptimizeType
+    $triangle: InputTriangle
     $itineraryFiltering: Float
     $unpreferred: InputUnpreferred
     $allowedBikeRentalNetworks: [String]
@@ -200,6 +201,7 @@ export const planQuery = graphql`
         transferPenalty: $transferPenalty
         bikeSpeed: $bikeSpeed
         optimize: $optimize
+        triangle: $triangle
         itineraryFiltering: $itineraryFiltering
         unpreferred: $unpreferred
         allowedBikeRentalNetworks: $allowedBikeRentalNetworks


### PR DESCRIPTION
## Proposed Changes
  - Added the triangle factors to the hbnext config.
  - Get triangle factors from the graphQL query.
  - Use these only when bike is also enabled, otherwise optimize type is QUICK.

## Review
  - Read and verify the code changes
  - Test the functionality by running the UI locally with all popular browsers available in your platform

closes #313