### PR TITLE
Next sharing popup fixes

### DIFF
--- a/app/component/CityBikeCard.js
+++ b/app/component/CityBikeCard.js
@@ -37,7 +37,7 @@ const CityBikeCard = (
       <CardHeader
         description={description}
         icon={getCityBikeNetworkIcon(networkConfig)}
-        name={station.name}
+        stop={station}
         unlinked
       />
       {children}

--- a/app/component/CityBikeContent.js
+++ b/app/component/CityBikeContent.js
@@ -11,24 +11,27 @@ import {
 import ComponentUsageExample from './ComponentUsageExample';
 import { station as exampleStation, lang as exampleLang } from './ExampleData';
 
-const CityBikeContent = ({ station, lang }, { config }) => (
+const CityBikeContent = ({ station, lang, type }, { config }) => (
   <div className="city-bike-container">
-    {station.state !== BIKESTATION_ON ? (
+    {station.state !== BIKESTATION_ON && (
       <p className="sub-header-h4 availability-header">
         <FormattedMessage
           id="citybike_off"
           defaultMessage="Bike station closed"
         />
       </p>
-    ) : (
-      <CityBikeAvailability
-        bikesAvailable={station.bikesAvailable}
-        totalSpaces={station.bikesAvailable + station.spacesAvailable}
-        fewAvailableCount={config.cityBike.fewAvailableCount}
-        type={getCityBikeType(station.networks, config)}
-        useSpacesAvailable={config.cityBike.useSpacesAvailable}
-      />
     )}
+    {station.state === BIKESTATION_ON &&
+      type !== 'taxi' &&
+      type !== 'car-sharing' && (
+        <CityBikeAvailability
+          bikesAvailable={station.bikesAvailable}
+          totalSpaces={station.bikesAvailable + station.spacesAvailable}
+          fewAvailableCount={config.cityBike.fewAvailableCount}
+          type={getCityBikeType(station.networks, config)}
+          useSpacesAvailable={config.cityBike.useSpacesAvailable}
+        />
+      )}
     {config.transportModes.citybike.availableForSelection &&
       getCityBikeUrl(station.networks, lang, config) && (
         <CityBikeUse
@@ -63,6 +66,7 @@ CityBikeContent.description = () => (
 CityBikeContent.propTypes = {
   station: PropTypes.object.isRequired,
   lang: PropTypes.string.isRequired,
+  type: PropTypes.string.isRequired,
 };
 
 CityBikeContent.contextTypes = {

--- a/app/component/map/popups/CityBikePopup.js
+++ b/app/component/map/popups/CityBikePopup.js
@@ -30,6 +30,7 @@ class CityBikePopup extends React.Component {
   };
 
   render() {
+    const type = this.props.station.networks[0];
     return (
       <div className="card">
         <CityBikeCardContainer
@@ -41,13 +42,15 @@ class CityBikePopup extends React.Component {
             station={this.props.station}
           />
         </CityBikeCardContainer>
-        <MarkerPopupBottom
-          location={{
-            address: this.props.station.name,
-            lat: this.props.station.lat,
-            lon: this.props.station.lon,
-          }}
-        />
+        {type !== 'taxi' && type !== 'car-sharing' && (
+          <MarkerPopupBottom
+            location={{
+              address: this.props.station.name,
+              lat: this.props.station.lat,
+              lon: this.props.station.lon,
+            }}
+          />
+        )}
       </div>
     );
   }

--- a/app/component/map/popups/CityBikePopup.js
+++ b/app/component/map/popups/CityBikePopup.js
@@ -30,7 +30,6 @@ class CityBikePopup extends React.Component {
   };
 
   render() {
-    const type = this.props.station.networks[0];
     return (
       <div className="card">
         <CityBikeCardContainer
@@ -42,15 +41,13 @@ class CityBikePopup extends React.Component {
             station={this.props.station}
           />
         </CityBikeCardContainer>
-        {type !== 'taxi' && type !== 'car-sharing' && (
-          <MarkerPopupBottom
-            location={{
-              address: this.props.station.name,
-              lat: this.props.station.lat,
-              lon: this.props.station.lon,
-            }}
-          />
-        )}
+        <MarkerPopupBottom
+          location={{
+            address: this.props.station.name,
+            lat: this.props.station.lat,
+            lon: this.props.station.lon,
+          }}
+        />
       </div>
     );
   }

--- a/app/component/map/popups/CityBikePopup.js
+++ b/app/component/map/popups/CityBikePopup.js
@@ -39,6 +39,7 @@ class CityBikePopup extends React.Component {
           <CityBikeContent
             lang={this.context.getStore('PreferencesStore').getLanguage()}
             station={this.props.station}
+            type={this.props.station.networks[0]}
           />
         </CityBikeCardContainer>
         <MarkerPopupBottom

--- a/sass/base/_elements.scss
+++ b/sass/base/_elements.scss
@@ -48,6 +48,7 @@ $border-radius-rounded: 30px;
   }
   .card-sub-header {
     display: flex;
+    margin-top: -17px;
     p {
       display: inline;
       margin-right: 2px;


### PR DESCRIPTION
## Proposed Changes
  - Fixed misused parameter so as the citybike popup shows the name of the station.
  - Removed "origin" and "destination" buttons from taxi and car-sharing popups.

## Review
  - Read and verify the code changes
  - Test the functionality by running the UI locally with all popular browsers available in your platform

closes #322