### PR TITLE
Fix default config

### DIFF
--- a/app/component/SelectMapLayersDialog.js
+++ b/app/component/SelectMapLayersDialog.js
@@ -90,57 +90,59 @@ class SelectMapLayersDialog extends React.Component {
   };
 
   renderMapModeSelector = (config, currentMapMode) => {
-    const { MAP } = config.URL;
-    if ('satellite' in MAP && 'bicycle' in MAP) {
-      return (
-        <div className="checkbox-grouping">
-          <h4>
-            <FormattedMessage
-              id="map-background"
-              defaultMessage="Map background"
-            />
-          </h4>
-          <label className="radio-label" htmlFor="street">
-            <input
-              type="radio"
-              id="street"
-              value="street"
-              name="mapMode"
-              onChange={() => {
-                this.switchMapLayers(MapMode.Default);
-              }}
-              checked={currentMapMode === MapMode.Default}
-            />
-            <FormattedMessage id="streets" defaultMessage="Streets" />
-          </label>
-          <label className="radio-label" htmlFor="satellite">
-            <input
-              type="radio"
-              id="satellite"
-              value="satellite"
-              name="mapMode"
-              onChange={() => {
-                this.switchMapLayers(MapMode.Satellite);
-              }}
-              checked={currentMapMode === MapMode.Satellite}
-            />
-            <FormattedMessage id="satellite" defaultMessage="Satellite" />
-          </label>
-          <label className="radio-label" htmlFor="bicycle">
-            <input
-              type="radio"
-              id="bicycle"
-              value="bicycle"
-              name="mapMode"
-              onChange={() => {
-                this.switchMapLayers(MapMode.Bicycle);
-              }}
-              checked={currentMapMode === MapMode.Bicycle}
-            />
-            <FormattedMessage id="bicycle" defaultMessage="Bicycle" />
-          </label>
-        </div>
-      );
+    if (config.URL) {
+      const { MAP } = config.URL;
+      if ('satellite' in MAP && 'bicycle' in MAP) {
+        return (
+          <div className="checkbox-grouping">
+            <h4>
+              <FormattedMessage
+                id="map-background"
+                defaultMessage="Map background"
+              />
+            </h4>
+            <label className="radio-label" htmlFor="street">
+              <input
+                type="radio"
+                id="street"
+                value="street"
+                name="mapMode"
+                onChange={() => {
+                  this.switchMapLayers(MapMode.Default);
+                }}
+                checked={currentMapMode === MapMode.Default}
+              />
+              <FormattedMessage id="streets" defaultMessage="Streets" />
+            </label>
+            <label className="radio-label" htmlFor="satellite">
+              <input
+                type="radio"
+                id="satellite"
+                value="satellite"
+                name="mapMode"
+                onChange={() => {
+                  this.switchMapLayers(MapMode.Satellite);
+                }}
+                checked={currentMapMode === MapMode.Satellite}
+              />
+              <FormattedMessage id="satellite" defaultMessage="Satellite" />
+            </label>
+            <label className="radio-label" htmlFor="bicycle">
+              <input
+                type="radio"
+                id="bicycle"
+                value="bicycle"
+                name="mapMode"
+                onChange={() => {
+                  this.switchMapLayers(MapMode.Bicycle);
+                }}
+                checked={currentMapMode === MapMode.Bicycle}
+              />
+              <FormattedMessage id="bicycle" defaultMessage="Bicycle" />
+            </label>
+          </div>
+        );
+      }
     }
     return null;
   };

--- a/app/component/SelectMapLayersDialog.js
+++ b/app/component/SelectMapLayersDialog.js
@@ -12,7 +12,7 @@ import MapLayerStore, { mapLayerShape } from '../store/MapLayerStore';
 import ComponentUsageExample from './ComponentUsageExample';
 import { addAnalyticsEvent } from '../util/analyticsUtils';
 import { replaceQueryParams, clearQueryParams } from '../util/queryUtils';
-import { MapMode } from '../constants';
+import { MapMode, GermanConfigs } from '../constants';
 import { setMapMode } from '../action/MapModeActions';
 
 class SelectMapLayersDialog extends React.Component {
@@ -111,6 +111,62 @@ class SelectMapLayersDialog extends React.Component {
     const isTransportModeEnabled = transportMode =>
       transportMode && transportMode.availableForSelection;
     const transportModes = config.transportModes || {};
+
+    const RenderMapModeSelector = () => {
+      if (config.CONFIG in GermanConfigs) {
+        return (
+          <div className="checkbox-grouping">
+            <h4>
+              <FormattedMessage
+                id="map-background"
+                defaultMessage="Map background"
+              />
+            </h4>
+            <label className="radio-label" htmlFor="street">
+              <input
+                type="radio"
+                id="street"
+                value="street"
+                name="mapMode"
+                onChange={() => {
+                  this.switchMapLayers(MapMode.Default);
+                }}
+                checked={currentMapMode === MapMode.Default}
+              />
+              <FormattedMessage id="streets" defaultMessage="Streets" />
+            </label>
+            <label className="radio-label" htmlFor="satellite">
+              <input
+                type="radio"
+                id="satellite"
+                value="satellite"
+                name="mapMode"
+                onChange={() => {
+                  this.switchMapLayers(MapMode.Satellite);
+                }}
+                checked={currentMapMode === MapMode.Satellite}
+              />
+              <FormattedMessage id="satellite" defaultMessage="Satellite" />
+            </label>
+            <label className="radio-label" htmlFor="bicycle">
+              <input
+                type="radio"
+                id="bicycle"
+                value="bicycle"
+                name="mapMode"
+                onChange={() => {
+                  this.switchMapLayers(MapMode.Bicycle);
+                }}
+                checked={currentMapMode === MapMode.Bicycle}
+              />
+              <FormattedMessage id="bicycle" defaultMessage="Bicycle" />
+            </label>
+          </div>
+        );
+      }
+      return null;
+    };
+
     return (
       <React.Fragment>
         {config.showAllBusses && (
@@ -350,53 +406,7 @@ class SelectMapLayersDialog extends React.Component {
               ))}
             </div>
           )}
-        <div className="checkbox-grouping">
-          <h4>
-            <FormattedMessage
-              id="map-background"
-              defaultMessage="Map background"
-            />
-          </h4>
-          <label className="radio-label" htmlFor="street">
-            <input
-              type="radio"
-              id="street"
-              value="street"
-              name="mapMode"
-              onChange={() => {
-                this.switchMapLayers(MapMode.Default);
-              }}
-              checked={currentMapMode === MapMode.Default}
-            />
-            <FormattedMessage id="streets" defaultMessage="Streets" />
-          </label>
-          <label className="radio-label" htmlFor="satellite">
-            <input
-              type="radio"
-              id="satellite"
-              value="satellite"
-              name="mapMode"
-              onChange={() => {
-                this.switchMapLayers(MapMode.Satellite);
-              }}
-              checked={currentMapMode === MapMode.Satellite}
-            />
-            <FormattedMessage id="satellite" defaultMessage="Satellite" />
-          </label>
-          <label className="radio-label" htmlFor="bicycle">
-            <input
-              type="radio"
-              id="bicycle"
-              value="bicycle"
-              name="mapMode"
-              onChange={() => {
-                this.switchMapLayers(MapMode.Bicycle);
-              }}
-              checked={currentMapMode === MapMode.Bicycle}
-            />
-            <FormattedMessage id="bicycle" defaultMessage="Bicycle" />
-          </label>
-        </div>
+        <RenderMapModeSelector />
       </React.Fragment>
     );
   };

--- a/app/component/SelectMapLayersDialog.js
+++ b/app/component/SelectMapLayersDialog.js
@@ -12,7 +12,7 @@ import MapLayerStore, { mapLayerShape } from '../store/MapLayerStore';
 import ComponentUsageExample from './ComponentUsageExample';
 import { addAnalyticsEvent } from '../util/analyticsUtils';
 import { replaceQueryParams, clearQueryParams } from '../util/queryUtils';
-import { MapMode, GermanConfigs } from '../constants';
+import { MapMode } from '../constants';
 import { setMapMode } from '../action/MapModeActions';
 
 class SelectMapLayersDialog extends React.Component {
@@ -90,7 +90,8 @@ class SelectMapLayersDialog extends React.Component {
   };
 
   renderMapModeSelector = (config, currentMapMode) => {
-    if (config.CONFIG in GermanConfigs) {
+    const { MAP } = config.URL;
+    if ('satellite' in MAP && 'bicycle' in MAP) {
       return (
         <div className="checkbox-grouping">
           <h4>

--- a/app/component/SelectMapLayersDialog.js
+++ b/app/component/SelectMapLayersDialog.js
@@ -89,6 +89,61 @@ class SelectMapLayersDialog extends React.Component {
     this.props.setMapMode(mapMode);
   };
 
+  renderMapModeSelector = (config, currentMapMode) => {
+    if (config.CONFIG in GermanConfigs) {
+      return (
+        <div className="checkbox-grouping">
+          <h4>
+            <FormattedMessage
+              id="map-background"
+              defaultMessage="Map background"
+            />
+          </h4>
+          <label className="radio-label" htmlFor="street">
+            <input
+              type="radio"
+              id="street"
+              value="street"
+              name="mapMode"
+              onChange={() => {
+                this.switchMapLayers(MapMode.Default);
+              }}
+              checked={currentMapMode === MapMode.Default}
+            />
+            <FormattedMessage id="streets" defaultMessage="Streets" />
+          </label>
+          <label className="radio-label" htmlFor="satellite">
+            <input
+              type="radio"
+              id="satellite"
+              value="satellite"
+              name="mapMode"
+              onChange={() => {
+                this.switchMapLayers(MapMode.Satellite);
+              }}
+              checked={currentMapMode === MapMode.Satellite}
+            />
+            <FormattedMessage id="satellite" defaultMessage="Satellite" />
+          </label>
+          <label className="radio-label" htmlFor="bicycle">
+            <input
+              type="radio"
+              id="bicycle"
+              value="bicycle"
+              name="mapMode"
+              onChange={() => {
+                this.switchMapLayers(MapMode.Bicycle);
+              }}
+              checked={currentMapMode === MapMode.Bicycle}
+            />
+            <FormattedMessage id="bicycle" defaultMessage="Bicycle" />
+          </label>
+        </div>
+      );
+    }
+    return null;
+  };
+
   renderContents = (
     {
       citybike,
@@ -111,61 +166,6 @@ class SelectMapLayersDialog extends React.Component {
     const isTransportModeEnabled = transportMode =>
       transportMode && transportMode.availableForSelection;
     const transportModes = config.transportModes || {};
-
-    const RenderMapModeSelector = () => {
-      if (config.CONFIG in GermanConfigs) {
-        return (
-          <div className="checkbox-grouping">
-            <h4>
-              <FormattedMessage
-                id="map-background"
-                defaultMessage="Map background"
-              />
-            </h4>
-            <label className="radio-label" htmlFor="street">
-              <input
-                type="radio"
-                id="street"
-                value="street"
-                name="mapMode"
-                onChange={() => {
-                  this.switchMapLayers(MapMode.Default);
-                }}
-                checked={currentMapMode === MapMode.Default}
-              />
-              <FormattedMessage id="streets" defaultMessage="Streets" />
-            </label>
-            <label className="radio-label" htmlFor="satellite">
-              <input
-                type="radio"
-                id="satellite"
-                value="satellite"
-                name="mapMode"
-                onChange={() => {
-                  this.switchMapLayers(MapMode.Satellite);
-                }}
-                checked={currentMapMode === MapMode.Satellite}
-              />
-              <FormattedMessage id="satellite" defaultMessage="Satellite" />
-            </label>
-            <label className="radio-label" htmlFor="bicycle">
-              <input
-                type="radio"
-                id="bicycle"
-                value="bicycle"
-                name="mapMode"
-                onChange={() => {
-                  this.switchMapLayers(MapMode.Bicycle);
-                }}
-                checked={currentMapMode === MapMode.Bicycle}
-              />
-              <FormattedMessage id="bicycle" defaultMessage="Bicycle" />
-            </label>
-          </div>
-        );
-      }
-      return null;
-    };
 
     return (
       <React.Fragment>
@@ -406,7 +406,7 @@ class SelectMapLayersDialog extends React.Component {
               ))}
             </div>
           )}
-        <RenderMapModeSelector />
+        {this.renderMapModeSelector(config, currentMapMode)}
       </React.Fragment>
     );
   };

--- a/app/component/map/Map.js
+++ b/app/component/map/Map.js
@@ -134,7 +134,6 @@ class Map extends React.Component {
   render() {
     const { zoom, boundsOptions } = this.props;
     const { config, router } = this.context;
-    const germanConfigs = ['hb', 'ludwigsburg'];
 
     const center =
       (!this.props.fitBounds &&
@@ -167,8 +166,6 @@ class Map extends React.Component {
       mapUrls.push(config.URL.MAP.semiTransparent);
     } else if (currentMapMode === MapMode.Bicycle) {
       mapUrls.push(config.URL.MAP.bicycle);
-    } else if (!germanConfigs.includes(config.CONFIG)) {
-      mapUrls.push(`${config.URL.MAP.default}{z}/{x}/{y}{size}.png`);
     } else {
       mapUrls.push(config.URL.MAP.default);
     }

--- a/app/component/map/Map.js
+++ b/app/component/map/Map.js
@@ -134,6 +134,7 @@ class Map extends React.Component {
   render() {
     const { zoom, boundsOptions } = this.props;
     const { config, router } = this.context;
+    const germanConfigs = ['hb', 'ludwigsburg'];
 
     const center =
       (!this.props.fitBounds &&
@@ -166,6 +167,8 @@ class Map extends React.Component {
       mapUrls.push(config.URL.MAP.semiTransparent);
     } else if (currentMapMode === MapMode.Bicycle) {
       mapUrls.push(config.URL.MAP.bicycle);
+    } else if (!germanConfigs.includes(config.CONFIG)) {
+      mapUrls.push(`${config.URL.MAP.default}{z}/{x}/{y}{size}.png`);
     } else {
       mapUrls.push(config.URL.MAP.default);
     }

--- a/app/component/map/Map.js
+++ b/app/component/map/Map.js
@@ -176,7 +176,12 @@ class Map extends React.Component {
     }
     */
 
-    const attribution = config.map.attribution[currentMapMode];
+    let attribution = null;
+    if (config.map.attribution) {
+      attribution = config.map.attribution[currentMapMode];
+    } else {
+      attribution = 'default';
+    }
 
     return (
       <div aria-hidden="true">

--- a/app/component/map/Map.js
+++ b/app/component/map/Map.js
@@ -179,8 +179,6 @@ class Map extends React.Component {
     let attribution = null;
     if (config.map.attribution) {
       attribution = config.map.attribution[currentMapMode];
-    } else {
-      attribution = 'default';
     }
 
     return (

--- a/app/configurations/config.default.js
+++ b/app/configurations/config.default.js
@@ -26,7 +26,7 @@ export default {
     MAP_URL,
     OTP: process.env.OTP_URL || `${API_URL}/routing/v1/routers/finland/`,
     MAP: {
-      default: `${MAP_URL}/map/v1/hsl-map/`,
+      default: `${MAP_URL}/map/v1/hsl-map/{z}/{x}/{y}{size}.png`,
       sv: `${MAP_URL}/map/v1/hsl-map-sv/`,
     },
     STOP_MAP: `${MAP_URL}/map/v1/finland-stop-map/`,

--- a/app/constants.js
+++ b/app/constants.js
@@ -38,6 +38,11 @@ export const MapMode = {
   Bicycle: 'bicycle',
 };
 
+export const GermanConfigs = {
+  hb: 'hb',
+  ludwigsburg: 'ludwigsburg',
+};
+
 /**
  * Mode depicts different kinds of mode available as any kind of transportation.
  */

--- a/app/constants.js
+++ b/app/constants.js
@@ -38,11 +38,6 @@ export const MapMode = {
   Bicycle: 'bicycle',
 };
 
-export const GermanConfigs = {
-  hb: 'hb',
-  ludwigsburg: 'ludwigsburg',
-};
-
 /**
  * Mode depicts different kinds of mode available as any kind of transportation.
  */


### PR DESCRIPTION
## Proposed Changes

  - fixed attribution error when different config loaded than `hb` or `ludwigsburg`
  - fixed default map for Finnish configs
  - bicycle and satellite map mode are no longer available for selection in Finnish configs


Before: 
![default-error](https://user-images.githubusercontent.com/54352878/110755615-6f82d200-8249-11eb-95dd-42b226439347.png)

After:
![image](https://user-images.githubusercontent.com/54352878/111132233-6495ad80-8579-11eb-8cf2-9e2b1353ded7.png)

`SelectMapLayersDialog`:
  - HSL:
![image](https://user-images.githubusercontent.com/54352878/111454562-0e5d7180-8715-11eb-83f6-a1912844d8fe.png)

  - stadtnavi:
![image](https://user-images.githubusercontent.com/54352878/111454730-45338780-8715-11eb-839f-85af4d2a8332.png)


## Review

  - Read and verify the code changes
  - Test the functionality by running the UI locally with all popular browsers available in your platform
 