### PR TITLE
Updates roadworks polyline icons

### DIFF
--- a/app/component/map/tile-layer/Roadworks.js
+++ b/app/component/map/tile-layer/Roadworks.js
@@ -108,12 +108,13 @@ class Roadworks {
       polyline[0],
       this.iconSize,
     ).then(
-      drawIcon(
-        `icon-icon_roadworks${suffix}`,
-        this.tile,
-        last(polyline),
-        this.iconSize,
-      ),
+      properties['location.direction'] === DirectionsType.BothDirections &&
+        drawIcon(
+          `icon-icon_roadworks${suffix}`,
+          this.tile,
+          last(polyline),
+          this.iconSize,
+        ),
     );
   };
 


### PR DESCRIPTION
## Proposed Changes

  - Only one roadworks icon for one direction closure

![image](https://user-images.githubusercontent.com/21622725/117818290-bea8ab80-b268-11eb-9c35-4a3b8dc2be21.png)


## Review

  - Read and verify the code changes
  - Test the functionality by running the UI locally with all popular browsers available in your platform

closes #424