### PR TITLE
Fix: Mode option colors on safari

### DIFF
--- a/app/component/customize-search.scss
+++ b/app/component/customize-search.scss
@@ -273,9 +273,6 @@
     display: flex;
     cursor: pointer;
 
-    span {
-      color: #000;
-    }
     .icon {
       font-size: 2.5em;
       margin-top: 0.2em;
@@ -297,6 +294,7 @@
       margin-top: 1.2em;
       width:100%;
       span {
+        color: #000;
         line-height: 1.1em;
       }
       .span-bike-not-allowed {


### PR DESCRIPTION
## Proposed Changes

  - Fixed Mode option colors on safari

![image](https://user-images.githubusercontent.com/21622725/117949999-04ba4980-b313-11eb-9261-393c81d3df8a.png)


## Review

  - Read and verify the code changes
  - Test the functionality by running the UI locally with all popular browsers available in your platform

closes #412 