### PR TITLE
Fix: Adds min-width to geojson popup

### DIFF
--- a/app/component/map/map.scss
+++ b/app/component/map/map.scss
@@ -410,6 +410,8 @@ div.leaflet-marker-icon.vehicle-icon {
   }
   .leaflet-popup-content {
     margin: 0;
+    width: auto !important;
+    min-width: 251px;
     &.leaflet-popup-scrolled {
       overflow: inherit;
       height: auto !important;


### PR DESCRIPTION
## Proposed Changes

  - Sets min-width to popup instead of width

![image](https://user-images.githubusercontent.com/21622725/119006319-8f90e900-b990-11eb-8b38-00027ecc3a51.png)

## Review

  - Read and verify the code changes
  - Test the functionality by running the UI locally with all popular browsers available in your platform

closes #480 