### PR TITLE
fix: Charge Stations icons have incorrect color

### DIFF
--- a/app/component/map/tile-layer/BikeParks.js
+++ b/app/component/map/tile-layer/BikeParks.js
@@ -67,7 +67,6 @@ class BikeParks {
 
   drawStatus = ({ geom, properties }) => {
     if (this.tile.coords.z <= this.config.bikeParks.smallIconZoom) {
-      const color = { 'mode-bike-park': '#005ab4' };
       return drawStopIcon(
         this.tile,
         geom,
@@ -75,7 +74,7 @@ class BikeParks {
         null,
         null,
         null,
-        color,
+        this.config.colors.iconColors,
       );
     }
 

--- a/app/component/map/tile-layer/ChargingStations.js
+++ b/app/component/map/tile-layer/ChargingStations.js
@@ -61,7 +61,15 @@ class ChargingStations {
 
   drawStatus = ({ geom, properties }) => {
     if (this.tile.coords.z <= this.config.chargingStations.smallIconZoom) {
-      return drawStopIcon(this.tile, geom, 'charging-station');
+      return drawStopIcon(
+        this.tile,
+        geom,
+        'charging-station',
+        null,
+        null,
+        null,
+        { 'mode-charging-station': '#00b096' },
+      );
     }
 
     const icon = getIcon(properties);

--- a/app/component/map/tile-layer/ChargingStations.js
+++ b/app/component/map/tile-layer/ChargingStations.js
@@ -68,7 +68,7 @@ class ChargingStations {
         null,
         null,
         null,
-        { 'mode-charging-station': '#00b096' },
+        this.config.colors.iconColors,
       );
     }
 

--- a/app/component/map/tile-layer/WeatherStations.js
+++ b/app/component/map/tile-layer/WeatherStations.js
@@ -61,7 +61,15 @@ export default class WeatherStations {
             if (
               this.tile.coords.z <= this.config.weatherStations.smallIconZoom
             ) {
-              return drawStopIcon(this.tile, feature.geom, 'monitor');
+              return drawStopIcon(
+                this.tile,
+                feature.geom,
+                'monitor',
+                null,
+                null,
+                null,
+                this.config.colors.iconColors,
+              );
             }
             return drawWeatherStationIcon(
               this.tile,

--- a/app/configurations/config.hbnext.js
+++ b/app/configurations/config.hbnext.js
@@ -90,6 +90,8 @@ export default configMerger(walttiConfig, {
             'mode-bus': '#ff0000',
             'mode-car': '#007AC9',
             'mode-rail': '#008000',
+            'mode-charging-station': '#00b096',
+            'mode-bike-park': '#005ab4',
         },
     },
 


### PR DESCRIPTION
Icons for charge stations appeared black when zoomed out.
Changed the color for the icon.

Closes #512 