### PR TITLE
fix(#549) Remove custom background color

### DIFF
--- a/app/component/util.scss
+++ b/app/component/util.scss
@@ -278,13 +278,16 @@ $btn-heigth: 17px;
   background-color: $standalone-btn-color;
   padding: $padding-small $padding-medium;
   border-radius: 20px;
+  color: $white;
+
   .icon-holder {
     padding: 0;
     margin: 0;
     margin-bottom: -4px;
   }
   &:hover {
-    background-color: $standalone-btn-hover-color;
+    background-color: $standalone-btn-color;
+    color: $white;
   }
 }
 

--- a/sass/base/_waltti.scss
+++ b/sass/base/_waltti.scss
@@ -3,5 +3,5 @@
 @import '../themes/default/theme';
 
 /* Component palette */
-$standalone-btn-hover-color: $gray;
-$standalone-btn-active-color: $gray;
+// $standalone-btn-hover-color: $gray;
+// $standalone-btn-active-color: $gray;


### PR DESCRIPTION
A custom color for the background of standalone buttons when hovered was the same as the font color.

Closes #549 