### PR TITLE
fix: #532 Minor UI Issues

### DIFF
--- a/app/component/summary.scss
+++ b/app/component/summary.scss
@@ -382,7 +382,7 @@
   text-align: left;
   padding-left: 81px;
   font-weight: $font-weight-medium;
-  font-size: 13px;
+  font-size: $font-size-normal;
   letter-spacing: -0.36px;
 
   .icon-container {
@@ -394,12 +394,8 @@
     transform: rotate(180deg);
   }
 
-  &.top-btn {
-    font-size: 13px;
-  }
   &.bottom-btn {
     border-top: 1px solid #ddd;
-    font-size: $font-size-normal;
     height: 50px;
   }
 }

--- a/digitransit-component/packages/digitransit-component-datetimepicker/src/helpers/Datetimepicker.js
+++ b/digitransit-component/packages/digitransit-component-datetimepicker/src/helpers/Datetimepicker.js
@@ -466,7 +466,7 @@ function Datetimepicker({
                     {` ${
                       moment().isSame(moment(displayTimestamp), 'day')
                         ? ''
-                        : getDateDisplay(displayTimestamp).toLowerCase()
+                        : getDateDisplay(displayTimestamp)
                     } ${getTimeDisplay(displayTimestamp)}`}
                   </>
                 )}


### PR DESCRIPTION
- Fixed `The abbreviation of the day should start with a capital letter like in the drop-down list`
- Fixed `The words "Früher" and "Später" don't have same font size or color`