### PR TITLE
fix(#556) Prevent empty locations

### DIFF
--- a/app/component/IndexPage.js
+++ b/app/component/IndexPage.js
@@ -87,11 +87,17 @@ class IndexPage extends React.Component {
 
     // synchronizing page init using fluxible is - hard -
     // see navigation conditions in componentDidUpdate below
-    if (!sameLocations(this.props.origin, origin)) {
+    if (
+      Object.keys(origin).length &&
+      !sameLocations(this.props.origin, origin)
+    ) {
       this.pendingOrigin = origin;
       this.context.executeAction(storeOrigin, origin);
     }
-    if (!sameLocations(this.props.destination, destination)) {
+    if (
+      Object.keys(destination).length &&
+      !sameLocations(this.props.destination, destination)
+    ) {
       this.pendingDestination = destination;
       this.context.executeAction(storeDestination, destination);
     }

--- a/app/component/IndexPage.js
+++ b/app/component/IndexPage.js
@@ -81,25 +81,23 @@ class IndexPage extends React.Component {
 
   componentDidMount() {
     const { from, to } = this.context.match.params;
-    /* initialize stores from URL params */
-    const origin = parseLocation(from);
-    const destination = parseLocation(to);
 
     // synchronizing page init using fluxible is - hard -
     // see navigation conditions in componentDidUpdate below
-    if (
-      Object.keys(origin).length &&
-      !sameLocations(this.props.origin, origin)
-    ) {
-      this.pendingOrigin = origin;
-      this.context.executeAction(storeOrigin, origin);
+    if (from) {
+      const origin = parseLocation(from);
+      if (!sameLocations(this.props.origin, origin)) {
+        this.pendingOrigin = origin;
+        this.context.executeAction(storeOrigin, origin);
+      }
     }
-    if (
-      Object.keys(destination).length &&
-      !sameLocations(this.props.destination, destination)
-    ) {
-      this.pendingDestination = destination;
-      this.context.executeAction(storeDestination, destination);
+
+    if (to) {
+      const destination = parseLocation(to);
+      if (!sameLocations(this.props.destination, destination)) {
+        this.pendingDestination = destination;
+        this.context.executeAction(storeDestination, destination);
+      }
     }
 
     scrollTop();


### PR DESCRIPTION
Prevent empty locations from setting the origin or destination to an empty object.

closes #556  