### PR TITLE
fix(#616) Missing translations

### DIFF
--- a/app/component/map/PointFeatureMarker.js
+++ b/app/component/map/PointFeatureMarker.js
@@ -143,14 +143,14 @@ const PointFeatureMarker = (
         isCustomIconVisible(zoom) || isRoundIconVisible(zoom)
       }
       onClick={() => {
-        const { name, popupContent: content, address, city } = properties;
+        const { name, popupContent, address, city } = properties;
         const params = pickBy(
           {
             lat,
             lng: lon,
-            name,
             language,
-            content,
+            name: properties[`name_${language}`] || name,
+            content: properties[`popupContent_${language}`] || popupContent,
             address,
             city,
           },

--- a/app/translations.js
+++ b/app/translations.js
@@ -268,6 +268,7 @@ const translations = {
     'report-defect': 'Mangel melden',
     'alert:bikerental:free-floating-drop-off':
       'Ziel ist keine Rückgabestation. Ausleihe kann hier nicht abgeschlossen werden. Anbieterabhängig fallen weiter Gebühren bis zur Rückgabe an einer Station an.',
+    day: 'Tag',
     monday: 'Montag',
     tuesday: 'Dienstag',
     wednesday: 'Mittwoch',


### PR DESCRIPTION
- Add German translation for 'day' to translations file
- Use localized names and description for GeoJSON markers

closes #616 