### PR TITLE
fix(#637) Prevent marker rendering from stoping

### DIFF
--- a/app/component/map/tile-layer/Stops.js
+++ b/app/component/map/tile-layer/Stops.js
@@ -111,10 +111,8 @@ class Stops {
             const drawRailPlatforms = this.config.railPlatformsMinZoom <= zoom;
             for (let i = 0, ref = vt.layers.stops.length - 1; i <= ref; i++) {
               const feature = vt.layers.stops.feature(i);
-              if (!isFeatureLayerEnabled(feature, 'stop', this.mapLayers)) {
-                break;
-              }
               if (
+                isFeatureLayerEnabled(feature, 'stop', this.mapLayers) &&
                 feature.properties.type &&
                 (feature.properties.parentStation === 'null' ||
                   drawPlatforms ||


### PR DESCRIPTION
When a layer is disabled the loop that adds the markers to be rendered is aborted. Now, instead, the loop continues.

```js
  if (!isFeatureLayerEnabled(feature, 'stop', this.mapLayers)) {
    break;
  }
```
