### PR TITLE
Make taxi, car sharing and cargo bike settings invisble in UI

### DIFF
--- a/app/component/CityBikeNetworkSelector.js
+++ b/app/component/CityBikeNetworkSelector.js
@@ -16,51 +16,53 @@ const CityBikeNetworkSelector = (
   { config, getStore, executeAction },
 ) => (
   <React.Fragment>
-    {mapDefaultNetworkProperties(config).map(network => (
-      <div
-        className="mode-option-block citybike-network-container"
-        key={`cb-${network.networkName}`}
-        style={{ height: '3.5em' }}
-      >
-        <label
-          htmlFor={`settings-toggle-bike-${network.networkName}`}
-          className="toggle-label"
+    {mapDefaultNetworkProperties(config)
+      .filter(network => network.visibleInSettingsUi)
+      .map(network => (
+        <div
+          className="mode-option-block citybike-network-container"
+          key={`cb-${network.networkName}`}
+          style={{ height: '3.5em' }}
         >
-          <Icon
-            className={`${network.icon}-icon`}
-            img={`icon-icon_${network.icon}`}
-            height={1}
-            width={1}
+          <label
+            htmlFor={`settings-toggle-bike-${network.networkName}`}
+            className="toggle-label"
+          >
+            <Icon
+              className={`${network.icon}-icon`}
+              img={`icon-icon_${network.icon}`}
+              height={1}
+              width={1}
+            />
+            <span className="network-name">
+              {getCityBikeNetworkName(
+                getCityBikeNetworkConfig(network.networkName, config),
+                getStore('PreferencesStore').getLanguage(),
+              )}
+            </span>
+          </label>
+          <Toggle
+            id={`settings-toggle-bike-${network.networkName}`}
+            toggled={
+              isUsingCitybike &&
+              currentOptions.filter(
+                option =>
+                  option.toLowerCase() === network.networkName.toLowerCase(),
+              ).length > 0
+            }
+            onToggle={() => {
+              executeAction(saveRoutingSettings, {
+                allowedBikeRentalNetworks: updateCitybikeNetworks(
+                  getCitybikeNetworks(config),
+                  network.networkName,
+                  config,
+                  isUsingCitybike,
+                ),
+              });
+            }}
           />
-          <span className="network-name">
-            {getCityBikeNetworkName(
-              getCityBikeNetworkConfig(network.networkName, config),
-              getStore('PreferencesStore').getLanguage(),
-            )}
-          </span>
-        </label>
-        <Toggle
-          id={`settings-toggle-bike-${network.networkName}`}
-          toggled={
-            isUsingCitybike &&
-            currentOptions.filter(
-              option =>
-                option.toLowerCase() === network.networkName.toLowerCase(),
-            ).length > 0
-          }
-          onToggle={() => {
-            executeAction(saveRoutingSettings, {
-              allowedBikeRentalNetworks: updateCitybikeNetworks(
-                getCitybikeNetworks(config),
-                network.networkName,
-                config,
-                isUsingCitybike,
-              ),
-            });
-          }}
-        />
-      </div>
-    ))}
+        </div>
+      ))}
   </React.Fragment>
 );
 

--- a/app/configurations/config.hbnext.js
+++ b/app/configurations/config.hbnext.js
@@ -171,6 +171,7 @@ export default configMerger(walttiConfig, {
                     de: 'https://www.regioradstuttgart.de/de',
                     en: 'https://www.regioradstuttgart.de/',
                 },
+                visibleInSettingsUi: true,
             },
             taxi: {
                 icon: 'taxi',
@@ -179,6 +180,7 @@ export default configMerger(walttiConfig, {
                     en: 'Taxi',
                 },
                 type: 'taxi',
+                visibleInSettingsUi: false,
             },
             "car-sharing": {
                 icon: 'car-sharing',
@@ -191,6 +193,7 @@ export default configMerger(walttiConfig, {
                     de: 'https://stuttgart.stadtmobil.de/privatkunden/',
                     en: 'https://stuttgart.stadtmobil.de/privatkunden/',
                 },
+                visibleInSettingsUi: false,
             },
             "cargo-bike": {
                 icon: 'cargobike',
@@ -198,7 +201,8 @@ export default configMerger(walttiConfig, {
                     de: 'Lastenrad Herrenberg',
                     en: 'Cargo bike Herrenberg',
                 },
-                type: 'cargo-bike'
+                type: 'cargo-bike',
+                visibleInSettingsUi: false,
             },
         }
     },


### PR DESCRIPTION
## Proposed Changes
  - added `visibleInSettingsUi` variable to each sharing network
  - set it false for taxi, car sharing and cargo bike (in order not to display them)

![image](https://user-images.githubusercontent.com/46535522/122643529-9423fb00-d110-11eb-86df-68190ed4ced4.png)


## Review
  - Read and verify the code changes
  - Test the functionality by running the UI locally with all popular browsers available in your platform

closes #654 