### PR TITLE
Bike and transit limits

### DIFF
--- a/app/component/SummaryPage.js
+++ b/app/component/SummaryPage.js
@@ -425,6 +425,25 @@ class SummaryPage extends React.Component {
       itinerary => !itinerary.legs.every(leg => leg.mode === 'WALK'),
     ).length === 0;
 
+  findLongestDuration = itineraries => {
+    return Math.max(...itineraries?.map(o => o.duration));
+  };
+
+  findShortestDuration = itineraries => {
+    return Math.min(...itineraries?.map(o => o.duration));
+  };
+
+  findLongestPublicItinerary = () => {
+    if (
+      this.props.viewer &&
+      this.props.viewer.plan &&
+      this.props.viewer.plan.itineraries
+    ) {
+      return this.findLongestDuration(this.props.viewer.plan.itineraries);
+    }
+    return 0;
+  };
+
   configClient = itineraryTopics => {
     const { config } = this.context;
     const { realTime } = config;
@@ -963,6 +982,23 @@ class SummaryPage extends React.Component {
             this.makeWeatherQuery();
           },
         );
+        // Remove bikeAndPublicPlan and bikeParkPlan itineraries if all public transport itineraries would last less.
+        if (
+          this.findLongestPublicItinerary() <
+          this.findShortestDuration(this.state.bikeAndPublicPlan?.itineraries)
+        ) {
+          this.setState({
+            bikeAndPublicPlan: undefined,
+          });
+        }
+        if (
+          this.findLongestPublicItinerary() <
+          this.findShortestDuration(this.state.bikeParkPlan?.itineraries)
+        ) {
+          this.setState({
+            bikeParkPlan: undefined,
+          });
+        }
       })
       .catch(() => {
         this.setState({ isFetchingWalkAndBike: false });
@@ -2717,6 +2753,7 @@ const containerComponent = createRefetchContainer(
           ...SummaryPlanContainer_plan
           ...ItineraryTab_plan
           itineraries {
+            duration
             startTime
             endTime
             ...ItineraryTab_itinerary

--- a/app/configurations/config.default.js
+++ b/app/configurations/config.default.js
@@ -147,7 +147,12 @@ export default {
 
   maxWalkDistance: 10000,
   suggestBikeMaxDistance: 30000,
+  // max walking distance in bike and public transport
   suggestBikeAndPublicMaxDistance: 15000,
+  // minimum linear distance in bike and take onto train (otherwise just cycle)
+  suggestBikeAndPublicMinDistance: 3000,
+  // minimum linear distance in bike and park / public transport (otherwise just cycle)
+  suggestBikeAndParkMinDistance: 3000,
   // if you enable car suggestions but the linear distance between all points is less than this, then a car route will
   // not be computed
   suggestCarMinDistance: 2000,

--- a/app/configurations/config.hbnext.js
+++ b/app/configurations/config.hbnext.js
@@ -567,6 +567,8 @@ export default configMerger(walttiConfig, {
 
     suggestCarMinDistance: 200,
     suggestWalkMaxDistance: 3000,
+    suggestBikeAndPublicMinDistance: 3000,
+    suggestBikeAndParkMinDistance: 3000,
 
     showVehiclesOnSummaryPage: true,
     showBikeAndPublicItineraries: true,

--- a/app/util/planParamUtil.js
+++ b/app/util/planParamUtil.js
@@ -362,11 +362,13 @@ export const preparePlanParams = (config, useDefaultModes) => (
     showBikeAndPublicItineraries:
       !wheelchair &&
       config.showBikeAndPublicItineraries &&
+      linearDistance >= config.suggestBikeAndPublicMinDistance &&
       modesOrDefault.length > 1 &&
       includeBikeSuggestions,
     showBikeAndParkItineraries:
       !wheelchair &&
       config.showBikeAndParkItineraries &&
+      linearDistance >= config.suggestBikeAndParkMinDistance &&
       modesOrDefault.length > 1 &&
       includeBikeSuggestions,
     bikeAndPublicMaxWalkDistance: config.suggestBikeAndPublicMaxDistance,


### PR DESCRIPTION
## Proposed Changes
#674 
  - added `suggestBikeAndPublicMinDistance: 3000` and `suggestBikeAndParkMinDistance: 3000`
  - do not show `bikeAndPublic` and `bikePark` itineraries if all of the suggestions are longer than the longest public transport suggestion

## Pull Request Check List
  - A reasonable set of unit tests is included
  - Console does not show new warnings/errors
  - Changes are documented or they are self explanatory
  - This pull request does not have any merge conflicts
  - All existing tests pass in CI build
  - Code coverage does not decrease (unless measured incorrectly)

## Review
  - Read and verify the code changes
  - *Test the functionality* by running the UI locally with all popular browsers available in your platform
  - Check that the implementation matches the design, when such one is defined in a Jira issue
  - Merge the pull request
