### PR TITLE
Refactor: Decrease roadworks polyline dot size

### DIFF
--- a/app/component/map/tile-layer/Roadworks.js
+++ b/app/component/map/tile-layer/Roadworks.js
@@ -89,8 +89,8 @@ class Roadworks {
       ctx.globalAlpha = 0.5;
     }
 
-    ctx.lineWidth = 12;
-    ctx.setLineDash([0.1, 24]);
+    ctx.lineWidth = 6;
+    ctx.setLineDash([0.1, 12]);
     ctx.lineCap = 'round';
     ctx.strokeStyle = '#cc2808';
 


### PR DESCRIPTION
## Proposed Changes

 I decreased the dot size of the roadworks dotted polyline. I think it looks much better now on low map zoom levels.

Now:
![image](https://user-images.githubusercontent.com/21622725/123830279-71a99300-d903-11eb-97ba-61ca3549bfc1.png)

Before:
![image](https://user-images.githubusercontent.com/21622725/123830711-d6fd8400-d903-11eb-90f1-12f2419d352f.png)

## Pull Request Check List

  - A reasonable set of unit tests is included
  - Console does not show new warnings/errors
  - Changes are documented or they are self explanatory
  - This pull request does not have any merge conflicts
  - All existing tests pass in CI build
  - Code coverage does not decrease (unless measured incorrectly)

## Review

  - Read and verify the code changes
  - Test the functionality by running the UI locally with all popular browsers available in your platform
  - Check that the implementation matches the design, when such one is defined in a Jira issue
  - Merge the pull request
