### PR TITLE
Fix: Map layer switcher always accessible

### DIFF
--- a/app/component/TopLevel.js
+++ b/app/component/TopLevel.js
@@ -64,10 +64,12 @@ class TopLevel extends React.Component {
     };
   }
 
-  // eslint-disable-next-line class-methods-use-this
-  MapLayersDialogContainer({ children, breakpoint, settingsOpen }) {
-    const isMobile = breakpoint !== 'large';
+  isMobile() {
+    return this.props.breakpoint !== 'large';
+  }
 
+  // eslint-disable-next-line class-methods-use-this
+  MapLayersDialogContainer({ children, settingsOpen, isMobile }) {
     return (
       <div
         className={cx(
@@ -218,7 +220,10 @@ class TopLevel extends React.Component {
             style={this.context.config.appBarStyle}
           />
         )}
-        <section id="mainContent" className="content">
+        <section
+          id="mainContent"
+          className={cx('content', this.isMobile() && 'mobile')}
+        >
           {this.props.meta}
           <noscript>This page requires JavaScript to run.</noscript>
           <ErrorBoundary
@@ -233,7 +238,7 @@ class TopLevel extends React.Component {
               this.props.settingsOpen !== null && (
                 <this.MapLayersDialogContainer
                   settingsOpen={this.props.settingsOpen}
-                  breakpoint={this.props.breakpoint}
+                  isMobile={this.isMobile()}
                 >
                   <MapLayersDialogContent
                     open={this.props.settingsOpen}

--- a/app/component/navigation.scss
+++ b/app/component/navigation.scss
@@ -523,6 +523,10 @@ section.content {
   flex-direction: column;
   flex: 0 1 100%;
 
+  &.mobile {
+    overflow-x: hidden;
+  }
+
   .mobile {
     display: flex;
     flex-direction: column;


### PR DESCRIPTION
## Proposed Changes

I noticed the layer switcher on mobile being always accessible, when swiping the screen to the left. This PR makes the layer switcher only visible and accessible, if user clicks on the map layer switcher button on the map.

![image](https://user-images.githubusercontent.com/21622725/123831125-48d5cd80-d904-11eb-9c67-a6482b524da3.png)

## Pull Request Check List

  - A reasonable set of unit tests is included
  - Console does not show new warnings/errors
  - Changes are documented or they are self explanatory
  - This pull request does not have any merge conflicts
  - All existing tests pass in CI build
  - Code coverage does not decrease (unless measured incorrectly)

## Review

  - Read and verify the code changes
  - Test the functionality by running the UI locally with all popular browsers available in your platform
  - Check that the implementation matches the design, when such one is defined in a Jira issue
  - Merge the pull request
