### PR TITLE
Fix: Clicking partly checked layer switcher category

### DIFF
--- a/app/component/LayerCategoryDropdown.js
+++ b/app/component/LayerCategoryDropdown.js
@@ -6,9 +6,10 @@ import merge from 'lodash/merge';
 import Checkbox from './Checkbox';
 import Icon from './Icon';
 import Message from './Message';
+import withBreakpoint from '../util/withBreakpoint';
 
 const LayerCategoryDropdown = (
-  { title, icon, options, onChange },
+  { title, icon, options, onChange, breakpoint },
   { intl },
 ) => {
   const [open, setOpen] = useState(false);
@@ -64,18 +65,29 @@ const LayerCategoryDropdown = (
     );
   };
 
+  const isMobile = breakpoint !== 'large';
+
   return (
     <div className="layer-category-dropdown-container">
       <div className="layer-category-dropdown-header">
         <div className="layer-category-dropdown-header-content">
           <Checkbox
             checked={checked || checkedPartly}
-            className="layer-category-dropdown-checkbox"
+            className={cx(
+              'layer-category-dropdown-checkbox',
+              isMobile && 'mobile',
+            )}
             icon={
               !checkedPartly ? 'icon-icon_check-white' : 'icon-icon_minus-white'
             }
             showLabel={false}
-            onChange={e => handleCheckAll(e.target.checked)}
+            onChange={e => {
+              if (checkedPartly) {
+                handleCheckAll(true);
+              } else {
+                handleCheckAll(e.target.checked);
+              }
+            }}
           />
           <Icon
             className="layer-category-dropdown-header-icon"
@@ -147,10 +159,11 @@ LayerCategoryDropdown.propTypes = {
   icon: PropTypes.string.isRequired,
   options: PropTypes.array.isRequired,
   onChange: PropTypes.func.isRequired,
+  breakpoint: PropTypes.string.isRequired,
 };
 
 LayerCategoryDropdown.contextTypes = {
   intl: intlShape.isRequired,
 };
 
-export default LayerCategoryDropdown;
+export default withBreakpoint(LayerCategoryDropdown);

--- a/sass/themes/hbnext/layer-category-dropdown.scss
+++ b/sass/themes/hbnext/layer-category-dropdown.scss
@@ -41,6 +41,14 @@
   &.checked {
     background: #9fc727 !important;
   }
+  &.mobile {
+    .icon-container {
+      .checkmark {
+        top: 0.03rem;
+        left: 0.03rem;
+      }
+    }
+  }
 }
 
 .layer-category-dropdown-option {


### PR DESCRIPTION
## Proposed Changes

  - Clicking partly checked layer switcher category should select all layers (Like mobile App does)

## Pull Request Check List

  - A reasonable set of unit tests is included
  - Console does not show new warnings/errors
  - Changes are documented or they are self explanatory
  - This pull request does not have any merge conflicts
  - All existing tests pass in CI build
  - Code coverage does not decrease (unless measured incorrectly)

## Review

  - Read and verify the code changes
  - Test the functionality by running the UI locally with all popular browsers available in your platform
  - Check that the implementation matches the design, when such one is defined in a Jira issue
  - Merge the pull request
