### PR TITLE
Display of delay information

### DIFF
--- a/app/component/BicycleLeg.js
+++ b/app/component/BicycleLeg.js
@@ -19,6 +19,7 @@ import { AlertSeverityLevelType } from '../constants';
 import ServiceAlertIcon from './ServiceAlertIcon';
 import { splitStringToAddressAndPlace } from '../util/otpStrings';
 import CityBikeLeg from './CityBikeLeg';
+import DelayedTime from './DelayedTime';
 
 function BicycleLeg(
   {
@@ -27,6 +28,8 @@ function BicycleLeg(
     leg,
     focusToLeg,
     arrivedAtDestinationWithRentedBicycle,
+    startTime,
+    previousLeg,
   },
   { config, intl },
 ) {
@@ -114,7 +117,11 @@ function BicycleLeg(
       </span>
       <div className="small-2 columns itinerary-time-column" aria-hidden="true">
         <div className="itinerary-time-column-time">
-          {moment(leg.startTime).format('HH:mm')}
+          <DelayedTime
+            leg={previousLeg}
+            delay={previousLeg && previousLeg.arrivalDelay}
+            startTime={startTime}
+          />
         </div>
       </div>
       {mode === 'BICYCLE' ? (
@@ -370,6 +377,10 @@ BicycleLeg.propTypes = {
   focusAction: PropTypes.func.isRequired,
   focusToLeg: PropTypes.func.isRequired,
   arrivedAtDestinationWithRentedBicycle: PropTypes.bool,
+  startTime: PropTypes.number.isRequired,
+  previousLeg: PropTypes.shape({
+    arrivalDelay: PropTypes.number,
+  }),
 };
 
 BicycleLeg.defaultProps = {

--- a/app/component/CarLeg.js
+++ b/app/component/CarLeg.js
@@ -13,6 +13,7 @@ import ServiceAlertIcon from './ServiceAlertIcon';
 import { AlertSeverityLevelType } from '../constants';
 import { replaceQueryParams } from '../util/queryUtils';
 import { getServiceAlertDescription } from '../util/alertUtils';
+import DelayedTime from './DelayedTime';
 
 function CarLeg(props, { config, intl, router, match, executeAction }) {
   const { leg } = props;
@@ -47,7 +48,11 @@ function CarLeg(props, { config, intl, router, match, executeAction }) {
       </span>
       <div className="small-2 columns itinerary-time-column" aria-hidden="true">
         <div className="itinerary-time-column-time">
-          {moment(leg.startTime).format('HH:mm')}
+          <DelayedTime
+            leg={props.previousLeg}
+            delay={props.previousLeg && props.previousLeg.arrivalDelay}
+            startTime={props.startTime}
+          />
         </div>
       </div>
       <ItineraryCircleLine index={props.index} modeClassName={modeClassName} />
@@ -216,6 +221,10 @@ CarLeg.propTypes = {
   focusAction: PropTypes.func.isRequired,
   children: PropTypes.node,
   toggleCarpoolDrawer: PropTypes.func,
+  startTime: PropTypes.number.isRequired,
+  previousLeg: PropTypes.shape({
+    arrivalDelay: PropTypes.number,
+  }),
 };
 
 CarLeg.contextTypes = {

--- a/app/component/DelayedTime.js
+++ b/app/component/DelayedTime.js
@@ -1,0 +1,44 @@
+import cx from 'classnames';
+import moment from 'moment';
+import React from 'react';
+import PropTypes from 'prop-types';
+import { legHasCancelation } from '../util/alertUtils';
+
+function DelayedTime({ leg, delay, startTime }, { config }) {
+  const realTime = leg !== undefined && leg.realTime;
+  const isLate =
+    delay !== undefined && delay >= config.itinerary.delayThreshold;
+  const tooEarly = delay !== undefined && delay < 0;
+  const originalTime = realTime &&
+    (isLate || tooEarly) && [
+      <br key="br" />,
+      <span key="time" className="original-time">
+        {moment(startTime).subtract(delay, 's').format('HH:mm')}
+      </span>,
+    ];
+
+  return (
+    <>
+      <span className={cx({ realtime: realTime, late: isLate })}>
+        <span className={cx({ canceled: legHasCancelation(leg) })}>
+          {moment(startTime).format('HH:mm')}
+        </span>
+      </span>
+      {originalTime}
+    </>
+  );
+}
+
+DelayedTime.propTypes = {
+  leg: PropTypes.shape({
+    realTime: PropTypes.bool.isRequired,
+  }),
+  delay: PropTypes.number,
+  startTime: PropTypes.number.isRequired,
+};
+
+DelayedTime.contextTypes = {
+  config: PropTypes.object.isRequired,
+};
+
+export default DelayedTime;

--- a/app/component/ItineraryLegs.js
+++ b/app/component/ItineraryLegs.js
@@ -134,6 +134,7 @@ class ItineraryLegs extends React.Component {
             index={j}
             leg={leg}
             arrivalTime={startTime}
+            previousLeg={previousLeg}
             focusAction={this.focus(leg.from)}
             focusToLeg={this.focusToLeg(leg)}
           />,
@@ -146,6 +147,7 @@ class ItineraryLegs extends React.Component {
             previousLeg={previousLeg}
             focusAction={this.focus(leg.from)}
             focusToLeg={this.focusToLeg(leg)}
+            startTime={startTime}
           >
             {this.stopCode(leg.from.stop)}
           </WalkLeg>,
@@ -237,6 +239,8 @@ class ItineraryLegs extends React.Component {
             arrivedAtDestinationWithRentedBicycle={
               itinerary.arrivedAtDestinationWithRentedBicycle
             }
+            startTime={startTime}
+            previousLeg={previousLeg}
           />,
         );
       } else if (leg.mode === 'CAR') {
@@ -246,6 +250,8 @@ class ItineraryLegs extends React.Component {
             leg={leg}
             focusAction={this.focus(leg.from)}
             toggleCarpoolDrawer={toggleCarpoolDrawer}
+            startTime={startTime}
+            previousLeg={previousLeg}
           >
             {this.stopCode(leg.from.stop)}
           </CarLeg>,
@@ -275,6 +281,7 @@ class ItineraryLegs extends React.Component {
               index={j}
               leg={leg}
               startTime={leg.endTime}
+              previousLeg={previousLeg}
               waitTime={waitTime}
               focusAction={this.focus(leg.to)}
             >

--- a/app/component/ItinerarySummaryListContainer.js
+++ b/app/component/ItinerarySummaryListContainer.js
@@ -71,6 +71,7 @@ function ItinerarySummaryListContainer(
         zones={
           config.zones.stops && itinerary.legs ? getZones(itinerary.legs) : []
         }
+        delayThreshold={config.itinerary.delayThreshold}
       />
     ));
     if (
@@ -362,6 +363,7 @@ const containerComponent = createFragmentContainer(
             alertId
           }
           realTime
+          departureDelay
           realtimeState
           transitLeg
           startTime

--- a/app/component/ItineraryTab.js
+++ b/app/component/ItineraryTab.js
@@ -457,6 +457,7 @@ const withRelay = createFragmentContainer(ItineraryTab, {
         startTime
         endTime
         departureDelay
+        arrivalDelay
         mode
         interlineWithPreviousLeg
         distance

--- a/app/component/ItineraryTab.js
+++ b/app/component/ItineraryTab.js
@@ -456,6 +456,7 @@ const withRelay = createFragmentContainer(ItineraryTab, {
         rentedBike
         startTime
         endTime
+        departureDelay
         mode
         interlineWithPreviousLeg
         distance

--- a/app/component/SummaryRow.js
+++ b/app/component/SummaryRow.js
@@ -790,7 +790,7 @@ SummaryRow.propTypes = {
   isCancelled: PropTypes.bool,
   showCancelled: PropTypes.bool,
   zones: PropTypes.arrayOf(PropTypes.string),
-  delayThreshold: PropTypes.number.isRequired,
+  delayThreshold: PropTypes.number,
 };
 
 SummaryRow.defaultProps = {

--- a/app/component/SummaryRow.js
+++ b/app/component/SummaryRow.js
@@ -223,6 +223,10 @@ const SummaryRow = (
   const startTime = moment(data.startTime);
   const endTime = moment(data.endTime);
   const duration = endTime.diff(startTime);
+  const isLate = leg =>
+    leg.realTime &&
+    leg.departureDelay !== undefined &&
+    leg.departureDelay >= props.delayThreshold;
 
   const mobile = bp => !(bp === 'large');
   const legs = [];
@@ -549,6 +553,7 @@ const SummaryRow = (
                 <span
                   className={cx('start-time', {
                     realtime: firstDeparture.realTime,
+                    late: isLate(firstDeparture),
                   })}
                 >
                   <LocalTime time={firstDeparture.startTime} />
@@ -785,6 +790,7 @@ SummaryRow.propTypes = {
   isCancelled: PropTypes.bool,
   showCancelled: PropTypes.bool,
   zones: PropTypes.arrayOf(PropTypes.string),
+  delayThreshold: PropTypes.number.isRequired,
 };
 
 SummaryRow.defaultProps = {

--- a/app/component/TransitLeg.js
+++ b/app/component/TransitLeg.js
@@ -176,9 +176,12 @@ class TransitLeg extends React.Component {
   renderMain = () => {
     const { children, focusAction, index, leg, mode, lang } = this.props;
     const { config, intl } = this.context;
-    const originalTime = leg.realTime &&
+    const isLate =
       leg.departureDelay !== undefined &&
-      leg.departureDelay >= config.itinerary.delayThreshold && [
+      leg.departureDelay >= config.itinerary.delayThreshold;
+    const tooEarly = leg.departureDelay !== undefined && leg.departureDelay < 0;
+    const originalTime = leg.realTime &&
+      (isLate || tooEarly) && [
         <br key="br" />,
         <span key="time" className="original-time">
           {moment(leg.startTime)
@@ -277,7 +280,7 @@ class TransitLeg extends React.Component {
           <span className="sr-only">{children}</span>
           <span aria-hidden="true">
             <div className="itinerary-time-column-time">
-              <span className={cx({ realtime: leg.realTime })}>
+              <span className={cx({ realtime: leg.realTime, late: isLate })}>
                 <span className={cx({ canceled: legHasCancelation(leg) })}>
                   {moment(leg.startTime).format('HH:mm')}
                 </span>

--- a/app/component/TransitLeg.js
+++ b/app/component/TransitLeg.js
@@ -17,7 +17,6 @@ import ServiceAlertIcon from './ServiceAlertIcon';
 import StopCode from './StopCode';
 import {
   getActiveAlertSeverityLevel,
-  legHasCancelation,
   tripHasCancelationForStop,
   getActiveLegAlerts,
   alertSeverityCompare,
@@ -32,6 +31,7 @@ import { shouldShowFareInfo } from '../util/fareUtils';
 import { AlertSeverityLevelType } from '../constants';
 import ZoneIcon from './ZoneIcon';
 import StopInfo from './StopInfo';
+import DelayedTime from './DelayedTime';
 
 class TransitLeg extends React.Component {
   constructor(props) {
@@ -176,19 +176,7 @@ class TransitLeg extends React.Component {
   renderMain = () => {
     const { children, focusAction, index, leg, mode, lang } = this.props;
     const { config, intl } = this.context;
-    const isLate =
-      leg.departureDelay !== undefined &&
-      leg.departureDelay >= config.itinerary.delayThreshold;
-    const tooEarly = leg.departureDelay !== undefined && leg.departureDelay < 0;
-    const originalTime = leg.realTime &&
-      (isLate || tooEarly) && [
-        <br key="br" />,
-        <span key="time" className="original-time">
-          {moment(leg.startTime)
-            .subtract(leg.departureDelay, 's')
-            .format('HH:mm')}
-        </span>,
-      ];
+
     const LegRouteName = leg.from.name?.concat(' - ').concat(leg.to.name);
     const modeClassName = mode.toLowerCase();
 
@@ -280,12 +268,11 @@ class TransitLeg extends React.Component {
           <span className="sr-only">{children}</span>
           <span aria-hidden="true">
             <div className="itinerary-time-column-time">
-              <span className={cx({ realtime: leg.realTime, late: isLate })}>
-                <span className={cx({ canceled: legHasCancelation(leg) })}>
-                  {moment(leg.startTime).format('HH:mm')}
-                </span>
-              </span>
-              {originalTime}
+              <DelayedTime
+                leg={leg}
+                delay={leg.departureDelay}
+                startTime={leg.startTime}
+              />
             </div>
             {zoneIcons}
           </span>

--- a/app/component/TransitLeg.js
+++ b/app/component/TransitLeg.js
@@ -177,7 +177,7 @@ class TransitLeg extends React.Component {
     const { children, focusAction, index, leg, mode, lang } = this.props;
     const { config, intl } = this.context;
     const originalTime = leg.realTime &&
-      leg.departureDelay &&
+      leg.departureDelay !== undefined &&
       leg.departureDelay >= config.itinerary.delayThreshold && [
         <br key="br" />,
         <span key="time" className="original-time">

--- a/app/component/ViaLeg.js
+++ b/app/component/ViaLeg.js
@@ -10,6 +10,7 @@ import { durationToString } from '../util/timeUtils';
 import ItineraryCircleLineWithIcon from './ItineraryCircleLineWithIcon';
 import { isKeyboardSelectionEvent } from '../util/browser';
 import { splitStringToAddressAndPlace } from '../util/otpStrings';
+import DelayedTime from './DelayedTime';
 
 const getDescription = (mode, distance, duration) => {
   if (mode === 'BICYCLE_WALK') {
@@ -84,7 +85,11 @@ function ViaLeg(props, { config, intl }) {
         aria-hidden="true"
       >
         <div className="itinerary-time-column-time via-arrival-time">
-          {moment(props.arrivalTime).format('HH:mm')}
+          <DelayedTime
+            leg={props.previousLeg}
+            delay={props.previousLeg && props.previousLeg.arrivalDelay}
+            startTime={props.arrivalTime}
+          />
         </div>
         <div className="itinerary-time-column-time via-divider">
           <div className="via-divider-line" />
@@ -219,6 +224,9 @@ ViaLeg.propTypes = {
   focusAction: PropTypes.func.isRequired,
   focusToLeg: PropTypes.func.isRequired,
   children: PropTypes.node,
+  previousLeg: PropTypes.shape({
+    arrivalDelay: PropTypes.number,
+  }),
 };
 
 ViaLeg.contextTypes = {

--- a/app/component/WaitLeg.js
+++ b/app/component/WaitLeg.js
@@ -9,10 +9,11 @@ import { durationToString } from '../util/timeUtils';
 import ItineraryCircleLineWithIcon from './ItineraryCircleLineWithIcon';
 import { isKeyboardSelectionEvent } from '../util/browser';
 import { PREFIX_STOPS } from '../util/path';
+import DelayedTime from './DelayedTime';
 
 /* eslint-disable jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions */
 function WaitLeg(
-  { children, leg, startTime, waitTime, focusAction, index },
+  { children, leg, startTime, waitTime, focusAction, index, previousLeg },
   { config, intl },
 ) {
   const modeClassName = 'wait';
@@ -28,7 +29,11 @@ function WaitLeg(
       </span>
       <div className="small-2 columns itinerary-time-column" aria-hidden="true">
         <div className="itinerary-time-column-time">
-          {moment(startTime).format('HH:mm')}
+          <DelayedTime
+            leg={previousLeg}
+            delay={previousLeg && previousLeg.arrivalDelay}
+            startTime={startTime}
+          />
         </div>
       </div>
       <ItineraryCircleLineWithIcon
@@ -153,6 +158,10 @@ WaitLeg.propTypes = {
       }),
     }).isRequired,
   }).isRequired,
+  previousLeg: PropTypes.shape({
+    realTime: PropTypes.bool.isRequired,
+    arrivalDelay: PropTypes.number,
+  }),
 };
 
 WaitLeg.contextTypes = {

--- a/app/component/WalkLeg.js
+++ b/app/component/WalkLeg.js
@@ -22,9 +22,10 @@ import { durationToString } from '../util/timeUtils';
 import { isKeyboardSelectionEvent } from '../util/browser';
 import { splitStringToAddressAndPlace } from '../util/otpStrings';
 import CityBikeLeg from './CityBikeLeg';
+import DelayedTime from './DelayedTime';
 
 function WalkLeg(
-  { children, focusAction, focusToLeg, index, leg, previousLeg },
+  { children, focusAction, focusToLeg, index, leg, previousLeg, startTime },
   { config, intl },
 ) {
   const distance = displayDistance(
@@ -82,7 +83,11 @@ function WalkLeg(
       </span>
       <div className="small-2 columns itinerary-time-column" aria-hidden="true">
         <div className="itinerary-time-column-time">
-          {moment(leg.startTime).format('HH:mm')}
+          <DelayedTime
+            leg={previousLeg}
+            delay={previousLeg && previousLeg.arrivalDelay}
+            startTime={startTime}
+          />
         </div>
       </div>
       <ItineraryCircleLineWithIcon
@@ -297,6 +302,7 @@ const walkLegShape = PropTypes.shape({
   to: PropTypes.shape({
     name: PropTypes.string.isRequired,
   }).isRequired,
+  arrivalDelay: PropTypes.number,
 });
 
 WalkLeg.propTypes = {
@@ -306,6 +312,7 @@ WalkLeg.propTypes = {
   leg: walkLegShape.isRequired,
   previousLeg: walkLegShape,
   focusToLeg: PropTypes.func.isRequired,
+  startTime: PropTypes.number.isRequired,
 };
 
 WalkLeg.defaultProps = {

--- a/app/component/stop.scss
+++ b/app/component/stop.scss
@@ -334,6 +334,9 @@
         &.realtime {
           color: $realtime-color;
         }
+        &.late {
+          color: $late-color;
+        }
         &.canceled {
           color: $cancelation-red;
         }
@@ -360,6 +363,9 @@
       &.realtime {
         color: $realtime-color;
       }
+      &.late {
+        color: $late-color;
+      }
       &.canceled {
         color: $cancelation-red;
       }
@@ -380,6 +386,9 @@
       color: #333;
       &.realtime {
         color: $realtime-color;
+      }
+      &.late {
+        color: $late-color;
       }
       &.canceled {
         color: $cancelation-red;

--- a/app/component/stops-near-you.scss
+++ b/app/component/stops-near-you.scss
@@ -295,6 +295,9 @@
         &.realtime {
           color: $realtime-color;
         }
+        &.late {
+          color: $late-color;
+        }
       }
       .route-number-container {
         background-color: currentColor;
@@ -323,6 +326,9 @@
         color: #333;
         &.realtime {
           color: $realtime-color;
+        }
+        &.late {
+          color: $late-color;
         }
       }
     }

--- a/sass/base/_helper-classes.scss
+++ b/sass/base/_helper-classes.scss
@@ -55,6 +55,9 @@
 .realtime {
   color: $realtime-color;
 }
+.late {
+  color: $late-color;
+}
 .to {
   color: $to-color;
 }

--- a/sass/themes/default/_theme.scss
+++ b/sass/themes/default/_theme.scss
@@ -36,6 +36,7 @@ $cancelation-black: #666;
 $cancelation-background: #fbe0ea;
 $disruption-color: $cancelation-red;
 $realtime-color: #46850E;
+$late-color: #FF4500;
 $visited-link-color: #8c4799;
 $current-location-color: $primary-color;
 $desktop-title-color: $primary-color;

--- a/test/unit/WalkLeg.test.js
+++ b/test/unit/WalkLeg.test.js
@@ -28,6 +28,7 @@ describe('<WalkLeg />', () => {
         rentedBike: false,
         startTime: 1529589709000,
       },
+      startTime: 1529589709000,
     };
 
     const wrapper = shallowWithIntl(<WalkLeg {...props} />, {
@@ -60,6 +61,7 @@ describe('<WalkLeg />', () => {
         startTime: 1529589709000,
       },
       previousLeg: {
+        realTime: false,
         distance: 3297.017000000001,
         duration: 904,
         from: {
@@ -74,6 +76,7 @@ describe('<WalkLeg />', () => {
           stop: null,
         },
       },
+      startTime: 1529589709000,
     };
 
     const wrapper = shallowWithIntl(<WalkLeg {...props} />, {
@@ -108,6 +111,7 @@ describe('<WalkLeg />', () => {
         startTime: 1529589709000,
       },
       previousLeg: {
+        realTime: false,
         distance: 3297.017000000001,
         duration: 904,
         from: {
@@ -125,6 +129,7 @@ describe('<WalkLeg />', () => {
         rentedBike: true,
         startTime: 1529588805000,
       },
+      startTime: 1529589709000,
     };
 
     const wrapper = shallowWithIntl(<WalkLeg {...props} />, {
@@ -172,6 +177,7 @@ describe('<WalkLeg />', () => {
         rentedBike: false,
         startTime,
       },
+      startTime,
     };
 
     const wrapper = shallowWithIntl(<WalkLeg {...props} />, {

--- a/test/unit/component/BicycleLeg.test.js
+++ b/test/unit/component/BicycleLeg.test.js
@@ -29,6 +29,7 @@ describe('<BicycleLeg />', () => {
           name: 'Testipaikka',
         },
       },
+      startTime: 0,
     };
     const wrapper = shallowWithIntl(<BicycleLeg {...props} />, {
       context: {
@@ -67,6 +68,7 @@ describe('<BicycleLeg />', () => {
           name: 'Testipaikka',
         },
       },
+      startTime: 0,
     };
     const wrapper = shallowWithIntl(<BicycleLeg {...props} />, {
       context: {
@@ -105,6 +107,7 @@ describe('<BicycleLeg />', () => {
           name: 'Testipaikka',
         },
       },
+      startTime: 0,
     };
     const wrapper = shallowWithIntl(<BicycleLeg {...props} />, {
       context: {
@@ -146,6 +149,7 @@ describe('<BicycleLeg />', () => {
           name: 'Testipaikka',
         },
       },
+      startTime: 0,
     };
     const wrapper = shallowWithIntl(<BicycleLeg {...props} />, {
       context: {
@@ -187,6 +191,7 @@ describe('<BicycleLeg />', () => {
           name: 'Testipaikka',
         },
       },
+      startTime: 0,
     };
     const wrapper = shallowWithIntl(<BicycleLeg {...props} />, {
       context: {
@@ -225,6 +230,7 @@ describe('<BicycleLeg />', () => {
           name: 'Testipaikka',
         },
       },
+      startTime: 0,
     };
     const wrapper = shallowWithIntl(<BicycleLeg {...props} />, {
       context: {

--- a/test/unit/component/TransitLeg.test.js
+++ b/test/unit/component/TransitLeg.test.js
@@ -25,6 +25,7 @@ describe('<TransitLeg />', () => {
     const props = {
       ...defaultProps,
       leg: {
+        realTime: false,
         from: {
           name: 'Lokkalantie',
           stop: {
@@ -88,6 +89,7 @@ describe('<TransitLeg />', () => {
     const props = {
       ...defaultProps,
       leg: {
+        realTime: false,
         from: {
           name: 'Lokkalantie',
           stop: {},
@@ -163,6 +165,7 @@ describe('<TransitLeg />', () => {
     const props = {
       ...defaultProps,
       leg: {
+        realTime: false,
         from: {
           name: 'Lokkalantie',
           stop: {
@@ -227,6 +230,7 @@ describe('<TransitLeg />', () => {
     const props = {
       ...defaultProps,
       leg: {
+        realTime: false,
         from: {
           name: 'Lokkalantie',
           stop: {
@@ -287,6 +291,7 @@ describe('<TransitLeg />', () => {
     const props = {
       ...defaultProps,
       leg: {
+        realTime: false,
         from: {
           name: 'Lokkalantie',
           stop: {},
@@ -347,6 +352,7 @@ describe('<TransitLeg />', () => {
     const props = {
       ...defaultProps,
       leg: {
+        realTime: false,
         from: {
           name: 'Huopalahti',
           stop: {},
@@ -406,6 +412,7 @@ describe('<TransitLeg />', () => {
     const props = {
       ...defaultProps,
       leg: {
+        realTime: false,
         endTime: 1553856420000,
         from: {
           name: 'Testilahti',
@@ -457,6 +464,7 @@ describe('<TransitLeg />', () => {
     const props = {
       ...defaultProps,
       leg: {
+        realTime: false,
         endTime: 1553856420000,
         from: {
           name: 'Testilahti',
@@ -513,6 +521,7 @@ describe('<TransitLeg />', () => {
     const props = {
       ...defaultProps,
       leg: {
+        realTime: false,
         endTime: 1553856420000,
         from: {
           name: 'Testilahti',
@@ -565,6 +574,7 @@ describe('<TransitLeg />', () => {
     const props = {
       ...defaultProps,
       leg: {
+        realTime: false,
         endTime: 1553856420000,
         from: {
           name: 'Testilahti',
@@ -617,6 +627,7 @@ describe('<TransitLeg />', () => {
     const props = {
       ...defaultProps,
       leg: {
+        realTime: false,
         endTime: 1553856420000,
         from: {
           name: 'Testilahti',
@@ -675,6 +686,7 @@ describe('<TransitLeg />', () => {
     const props = {
       ...defaultProps,
       leg: {
+        realTime: false,
         fare: {
           isUnknown: true,
           agency: {
@@ -730,6 +742,7 @@ describe('<TransitLeg />', () => {
     const props = {
       ...defaultProps,
       leg: {
+        realTime: false,
         fare: {
           isUnknown: true,
           agency: {
@@ -786,6 +799,7 @@ describe('<TransitLeg />', () => {
     const props = {
       ...defaultProps,
       leg: {
+        realTime: false,
         from: {
           name: 'Test',
           stop: {
@@ -841,6 +855,7 @@ describe('<TransitLeg />', () => {
     const props = {
       ...defaultProps,
       leg: {
+        realTime: false,
         from: {
           name: 'Test',
           stop: {},
@@ -906,6 +921,7 @@ describe('<TransitLeg />', () => {
     const props = {
       ...defaultProps,
       leg: {
+        realTime: false,
         from: {
           name: 'Test',
           stop: {},


### PR DESCRIPTION
## Proposed Changes
#746 

In the itinerary details
  - show departure too early in green and original time crossed out
  - show late departure in reddish orange and original time crossed out
  - display arrival time of previous leg (and too early / late coloring)

On the summary page
  - show late first departure time in reddish orange

## Pull Request Check List
  - A reasonable set of unit tests is included
  - Console does not show new warnings/errors
  - Changes are documented or they are self explanatory
  - This pull request does not have any merge conflicts
  - All existing tests pass in CI build
  - Code coverage does not decrease (unless measured incorrectly)

## Review
  - Read and verify the code changes
  - Test the functionality by running the UI locally with all popular browsers available in your platform
  - Check that the implementation matches the design, when such one is defined in a Jira issue
  - Merge the pull request
