### PR TITLE
Add scooter stop fallback message

### DIFF
--- a/app/component/BikeRentalStationPageMapContainer.js
+++ b/app/component/BikeRentalStationPageMapContainer.js
@@ -19,6 +19,10 @@ BikeRentalStationPageMapContainer.propTypes = {
     lat: PropTypes.number.isRequired,
     lon: PropTypes.number.isRequired,
     name: PropTypes.string,
+    networks: PropTypes.oneOfType([
+      PropTypes.string,
+      PropTypes.arrayOf(PropTypes.string),
+    ]).isRequired,
   }),
 };
 
@@ -34,6 +38,7 @@ const containerComponent = createFragmentContainer(
         lat
         lon
         name
+        networks
       }
     `,
   },

--- a/app/component/SelectedStopPopupContent.js
+++ b/app/component/SelectedStopPopupContent.js
@@ -3,14 +3,14 @@ import React from 'react';
 
 import { FormattedMessage } from 'react-intl';
 
-const SelectedStopPopupContent = ({ stop, citybike }) => (
+const SelectedStopPopupContent = ({ stop }) => (
   <div className="origin-popup">
     <div className="origin-popup-header">
       <div className="selected-stop-header">
-        {!stop.name && citybike ? (
+        {!stop.name || stop.networks[0] === 'tier_REUTLINGEN' ? (
           <FormattedMessage
-            id="tier-reutlingen-station-no-id"
-            defaultMessage="Scooter"
+            id={`${stop.networks}-station-no-id`}
+            defaultMessage="Station"
           />
         ) : (
           stop.name
@@ -33,11 +33,10 @@ const SelectedStopPopupContent = ({ stop, citybike }) => (
 
 SelectedStopPopupContent.propTypes = {
   stop: PropTypes.object.isRequired,
-  citybike: PropTypes.bool,
-};
-
-SelectedStopPopupContent.defaultProps = {
-  citybike: false,
+  networks: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.arrayOf(PropTypes.string),
+  ]).isRequired,
 };
 
 SelectedStopPopupContent.displayName = 'SelectedStopPopupContent';

--- a/app/component/SelectedStopPopupContent.js
+++ b/app/component/SelectedStopPopupContent.js
@@ -1,10 +1,21 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 
-const SelectedStopPopupContent = ({ stop }) => (
+import { FormattedMessage } from 'react-intl';
+
+const SelectedStopPopupContent = ({ stop, citybike }) => (
   <div className="origin-popup">
     <div className="origin-popup-header">
-      <div className="selected-stop-header">{stop.name}</div>
+      <div className="selected-stop-header">
+        {!stop.name && citybike ? (
+          <FormattedMessage
+            id="tier-reutlingen-station-no-id"
+            defaultMessage="Scooter"
+          />
+        ) : (
+          stop.name
+        )}
+      </div>
     </div>
     {(stop.code || stop.desc) && (
       <div>
@@ -22,6 +33,11 @@ const SelectedStopPopupContent = ({ stop }) => (
 
 SelectedStopPopupContent.propTypes = {
   stop: PropTypes.object.isRequired,
+  citybike: PropTypes.bool,
+};
+
+SelectedStopPopupContent.defaultProps = {
+  citybike: false,
 };
 
 SelectedStopPopupContent.displayName = 'SelectedStopPopupContent';

--- a/app/component/map/StopPageMap.js
+++ b/app/component/map/StopPageMap.js
@@ -103,7 +103,7 @@ const StopPageMap = (
   if (breakpoint === 'large') {
     leafletObjs.push(
       <SelectedStopPopup lat={stop.lat} lon={stop.lon} key="SelectedStopPopup">
-        <SelectedStopPopupContent stop={stop} citybike />
+        <SelectedStopPopupContent stop={stop} />
       </SelectedStopPopup>,
     );
   } else {

--- a/app/component/map/StopPageMap.js
+++ b/app/component/map/StopPageMap.js
@@ -191,12 +191,10 @@ StopPageMap.propTypes = {
   currentTime: PropTypes.number.isRequired,
   mapLayers: mapLayerShape.isRequired,
   mapLayerOptions: mapLayerOptionsShape.isRequired,
-  citybike: PropTypes.bool,
 };
 
 StopPageMap.defaultProps = {
   stop: undefined,
-  citybike: false,
 };
 
 const componentWithBreakpoint = withBreakpoint(StopPageMap);

--- a/app/component/map/StopPageMap.js
+++ b/app/component/map/StopPageMap.js
@@ -103,7 +103,7 @@ const StopPageMap = (
   if (breakpoint === 'large') {
     leafletObjs.push(
       <SelectedStopPopup lat={stop.lat} lon={stop.lon} key="SelectedStopPopup">
-        <SelectedStopPopupContent stop={stop} />
+        <SelectedStopPopupContent stop={stop} citybike />
       </SelectedStopPopup>,
     );
   } else {
@@ -191,10 +191,12 @@ StopPageMap.propTypes = {
   currentTime: PropTypes.number.isRequired,
   mapLayers: mapLayerShape.isRequired,
   mapLayerOptions: mapLayerOptionsShape.isRequired,
+  citybike: PropTypes.bool,
 };
 
 StopPageMap.defaultProps = {
   stop: undefined,
+  citybike: false,
 };
 
 const componentWithBreakpoint = withBreakpoint(StopPageMap);


### PR DESCRIPTION
## Proposed Changes
* extended the bike rental station query with the `networks` property
* added condition: display a fallback message based on `station.networks` if `station.name` is not given or if the network is `tier-reutlingen`

![image](https://user-images.githubusercontent.com/46535522/132946327-c034fca4-720d-416b-b7af-31d0cf814343.png)

## Pull Request Check List

  - A reasonable set of unit tests is included
  - Console does not show new warnings/errors
  - Changes are documented or they are self explanatory
  - This pull request does not have any merge conflicts
  - All existing tests pass in CI build
  - Code coverage does not decrease (unless measured incorrectly)

## Review

  - Read and verify the code changes
  - Test the functionality by running the UI locally with all popular browsers available in your platform
  - Check that the implementation matches the design, when such one is defined in a Jira issue
  - Merge the pull request

Closes #760