### PR TITLE
Update popup styling

### DIFF
--- a/app/component/map/tile-layer/MarkerSelectPopup.js
+++ b/app/component/map/tile-layer/MarkerSelectPopup.js
@@ -11,7 +11,7 @@ import { options } from '../../ExampleData';
 import SelectCarpoolRow from './SelectCarpoolRow';
 import SelectBikeParkRow from './SelectBikeParkRow';
 import SelectDynamicParkingLotsRow from './SelectDynamicParkingLotsRow';
-import RoadworksRow from './RoadworksRow';
+import SelectRoadworksRow from './SelectRoadworksRow';
 import SelectChargingStationRow from './SelectChargingStationRow';
 
 function MarkerSelectPopup(props) {
@@ -112,7 +112,7 @@ function MarkerSelectPopup(props) {
     }
     if (option.layer === 'roadworks') {
       return (
-        <RoadworksRow
+        <SelectRoadworksRow
           {...option.feature}
           key={option.feature.properties.id}
           selectRow={() => props.selectRow(option)}

--- a/app/component/map/tile-layer/RoadworksRow.js
+++ b/app/component/map/tile-layer/RoadworksRow.js
@@ -7,22 +7,20 @@ export default function RoadworksRow(props) {
   const { selectRow, properties } = props;
 
   return (
-    <div className="no-margin">
-      {/* eslint-disable-next-line jsx-a11y/click-events-have-key-events,jsx-a11y/no-static-element-interactions */}
-      <div className="cursor-pointer select-row" onClick={selectRow}>
-        <div className="padding-vertical-normal select-row-icon">
-          <Icon
-            img={`icon-icon_roadworks${Roadworks.getIconSuffix(properties)}`}
-            viewBox="0 0 600.995 600.995"
-          />
-        </div>
-        <div className="padding-vertical-normal select-row-text">
-          <span className="header-primary no-margin link-color">
-            {properties['location.street']}
-          </span>
-        </div>
-        <div className="clear" />
+    // eslint-disable-next-line jsx-a11y/click-events-have-key-events,jsx-a11y/no-static-element-interactions
+    <div className="stop-popup-choose-row" onClick={selectRow}>
+      <div className="padding-vertical-normal select-row-icon">
+        <Icon
+          img={`icon-icon_roadworks${Roadworks.getIconSuffix(properties)}`}
+          viewBox="0 0 600.995 600.995"
+        />
       </div>
+      <span className="choose-row-center-column">
+        <h5 className="choose-row-header">{properties['location.street']}</h5>
+      </span>
+      <span className="choose-row-right-column">
+        <Icon img="icon-icon_arrow-collapse--right" />
+      </span>
       <hr className="no-margin gray" />
     </div>
   );

--- a/app/component/map/tile-layer/SelectBikeParkRow.js
+++ b/app/component/map/tile-layer/SelectBikeParkRow.js
@@ -7,19 +7,17 @@ export default function SelectBikeParkRow(props) {
   const { selectRow, properties } = props;
   const icon = BikeParks.getIcon(properties);
   return (
-    <div className="no-margin">
-      {/* eslint-disable-next-line jsx-a11y/no-static-element-interactions,jsx-a11y/click-events-have-key-events */}
-      <div className="cursor-pointer select-row" onClick={selectRow}>
-        <div className="padding-vertical-normal select-row-icon">
-          <Icon img={icon} viewBox="0 0 18 18" />
-        </div>
-        <div className="padding-vertical-normal select-row-text">
-          <span className="header-primary no-margin link-color">
-            {properties.name}
-          </span>
-        </div>
-        <div className="clear" />
+    // eslint-disable-next-line jsx-a11y/click-events-have-key-events,jsx-a11y/no-static-element-interactions
+    <div className="stop-popup-choose-row" onClick={selectRow}>
+      <div className="padding-vertical-normal select-row-icon">
+        <Icon img={icon} viewBox="0 0 18 18" />
       </div>
+      <span className="choose-row-center-column">
+        <h5 className="choose-row-header">{properties.name}</h5>
+      </span>
+      <span className="choose-row-right-column">
+        <Icon img="icon-icon_arrow-collapse--right" />
+      </span>
       <hr className="no-margin gray" />
     </div>
   );

--- a/app/component/map/tile-layer/SelectCarpoolRow.js
+++ b/app/component/map/tile-layer/SelectCarpoolRow.js
@@ -6,19 +6,17 @@ export default function SelectCarpoolRow(props) {
   const { selectRow, properties } = props;
 
   return (
-    <div className="no-margin">
-      {/* eslint-disable-next-line jsx-a11y/click-events-have-key-events,jsx-a11y/no-static-element-interactions */}
-      <div className="cursor-pointer select-row" onClick={selectRow}>
-        <div className="padding-vertical-normal select-row-icon">
-          <Icon img="icon-icon_carpark_carpool" viewBox="0 0 600.995 600.995" />
-        </div>
-        <div className="padding-vertical-normal select-row-text">
-          <span className="header-primary no-margin link-color">
-            {properties.name}
-          </span>
-        </div>
-        <div className="clear" />
+    // eslint-disable-next-line jsx-a11y/click-events-have-key-events,jsx-a11y/no-static-element-interactions
+    <div className="stop-popup-choose-row" onClick={selectRow}>
+      <div className="padding-vertical-normal select-row-icon">
+        <Icon img="icon-icon_carpark_carpool" viewBox="0 0 600.995 600.995" />
       </div>
+      <span className="choose-row-center-column">
+        <h5 className="choose-row-header">{properties.name}</h5>
+      </span>
+      <span className="choose-row-right-column">
+        <Icon img="icon-icon_arrow-collapse--right" />
+      </span>
       <hr className="no-margin gray" />
     </div>
   );

--- a/app/component/map/tile-layer/SelectChargingStationRow.js
+++ b/app/component/map/tile-layer/SelectChargingStationRow.js
@@ -6,19 +6,17 @@ import { getIcon } from '../sidebar/ChargingStationContent';
 export default function SelectChargingStationsRow(props) {
   const { selectRow, properties } = props;
   return (
-    <div className="no-margin">
-      {/* eslint-disable-next-line jsx-a11y/no-static-element-interactions,jsx-a11y/click-events-have-key-events */}
-      <div className="cursor-pointer select-row" onClick={selectRow}>
-        <div className="padding-vertical-normal select-row-icon">
-          <Icon img={getIcon(properties)} viewBox="0 0 18 18" />
-        </div>
-        <div className="padding-vertical-normal select-row-text">
-          <span className="header-primary no-margin link-color">
-            {properties.name}
-          </span>
-        </div>
-        <div className="clear" />
+    // eslint-disable-next-line jsx-a11y/click-events-have-key-events,jsx-a11y/no-static-element-interactions
+    <div className="stop-popup-choose-row" onClick={selectRow}>
+      <div className="padding-vertical-normal select-row-icon">
+        <Icon img={getIcon(properties)} viewBox="0 0 18 18" />
       </div>
+      <span className="choose-row-center-column">
+        <h5 className="choose-row-header">{properties.name}</h5>
+      </span>
+      <span className="choose-row-right-column">
+        <Icon img="icon-icon_arrow-collapse--right" />
+      </span>
       <hr className="no-margin gray" />
     </div>
   );

--- a/app/component/map/tile-layer/SelectParkAndRideRow.js
+++ b/app/component/map/tile-layer/SelectParkAndRideRow.js
@@ -8,18 +8,19 @@ import ComponentUsageExample from '../../ComponentUsageExample';
 /* eslint-disable jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions */
 function SelectParkAndRideRow(props, { intl }) {
   return (
-    <div className="no-margin">
-      <div className="cursor-pointer select-row" onClick={props.selectRow}>
-        <div className="padding-vertical-normal select-row-icon">
-          <Icon img="icon-icon_car" color={props.colors.primary} />
-        </div>
-        <div className="padding-vertical-normal select-row-text">
-          <span className="header-primary no-margin link-color">
-            {JSON.parse(props.name)[intl.locale]} ›
-          </span>
-        </div>
-        <div className="clear" />
+    // eslint-disable-next-line jsx-a11y/click-events-have-key-events,jsx-a11y/no-static-element-interactions
+    <div className="stop-popup-choose-row" onClick={props.selectRow}>
+      <div className="padding-vertical-normal select-row-icon">
+        <Icon img="icon-icon_car" color={props.colors.primary} />
       </div>
+      <span className="choose-row-center-column">
+        <h5 className="choose-row-header">
+          {JSON.parse(props.name)[intl.locale]}
+        </h5>
+      </span>
+      <span className="choose-row-right-column">
+        <Icon img="icon-icon_arrow-collapse--right" />
+      </span>
       <hr className="no-margin gray" />
     </div>
   );

--- a/app/component/map/tile-layer/SelectRoadworksRow.js
+++ b/app/component/map/tile-layer/SelectRoadworksRow.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import Icon from '../../Icon';
 import Roadworks from './Roadworks';
 
-export default function RoadworksRow(props) {
+export default function SelectRoadworksRow(props) {
   const { selectRow, properties } = props;
 
   return (
@@ -26,7 +26,7 @@ export default function RoadworksRow(props) {
   );
 }
 
-RoadworksRow.propTypes = {
+SelectRoadworksRow.propTypes = {
   selectRow: PropTypes.func.isRequired,
   properties: PropTypes.object.isRequired,
 };

--- a/app/translations.js
+++ b/app/translations.js
@@ -427,7 +427,7 @@ const translations = {
     'charging-spaces-available': '{available} von {capacity} Ladeplätzen frei',
     'charging-spaces-in-total': '{capacity} Ladeplätze',
     'charging-spaces-no-data' : 'Keine Daten zu den Ladeplätze vorhanden',
-    'choose-stop': 'Haltestelle auswählen',
+    'choose-stop': 'Option auswählen',
     'choose-stop-or-vehicle': 'Fahrzeug oder Haltestelle auswählen',
     'choose-vehicle': 'Fahrzeug auswählen',
     'direction': 'Ri. ',


### PR DESCRIPTION
## Proposed Changes
Based on #763
* Changed the popup header text.
* Fixed the styling of the popup selector rows of the different POI types (roadwork, bike park, park and ride, carpool, charging station). They all use the new, DT2 variant.
* Renamed `RoadworksRow` to `SelectRoadworksRow` to keep the component naming convention.

## Pull Request Check List

  - A reasonable set of unit tests is included
  - Console does not show new warnings/errors
  - Changes are documented or they are self explanatory
  - This pull request does not have any merge conflicts
  - All existing tests pass in CI build
  - Code coverage does not decrease (unless measured incorrectly)

## Review

  - Read and verify the code changes
  - Test the functionality by running the UI locally with all popular browsers available in your platform
  - Check that the implementation matches the design, when such one is defined in a Jira issue
  - Merge the pull request
