### PR TITLE
feat(map attributions): consider attributions based on map mode

### DIFF
--- a/app/component/map/Map.js
+++ b/app/component/map/Map.js
@@ -254,6 +254,8 @@ class Map extends React.Component {
     }
 
     let attribution = get(config, 'map.attribution.default');
+    const currentMapMode = getMapMode(this.context.match);
+    attribution = config.map.attribution[currentMapMode] || attribution;
     if (!isString(attribution) || isEmpty(attribution)) {
       attribution = false;
     }


### PR DESCRIPTION
- used the current map mode to get the different attributions from configs
- still using the default one if attribution for a map mode wouldn't be set