### PR TITLE
Use default map layer if other URLs are not set

### DIFF
--- a/app/component/map/Map.js
+++ b/app/component/map/Map.js
@@ -364,10 +364,14 @@ class Map extends React.Component {
     const mapUrls = [];
     if (isDebugTiles) {
       mapUrls.push(`${config.URL.OTP}inspector/tile/traversal/{z}/{x}/{y}.png`);
-    } else if (currentMapMode === MapMode.Satellite) {
+    } else if (
+      currentMapMode === MapMode.Satellite &&
+      config.URL.MAP.satellite &&
+      config.URL.MAP.semiTransparent
+    ) {
       mapUrls.push(config.URL.MAP.satellite);
       mapUrls.push(config.URL.MAP.semiTransparent);
-    } else if (currentMapMode === MapMode.Bicycle) {
+    } else if (currentMapMode === MapMode.Bicycle && config.URL.MAP.bicycle) {
       mapUrls.push(config.URL.MAP.bicycle);
     } else {
       mapUrls.push(config.URL.MAP.default);


### PR DESCRIPTION
## Proposed Changes

If the URL of a map layer is empty or not specified, fall back to the default map layer.

## Rationale

This way it is possible use stadtnavi with only one background map by setting only one map URL: `config.URL.MAP.default`.

It is already possible to hide the map layer selector via `config.map.showLayerSelector`. But if one searches for connections and selects one with bike sections, the `mapMode` changes to `MapMode.Bicycle`.

Before this commit, this resulted in an error where one does no longer see any map. With the proposed changes, the background would not change and still work.

## Pull Request Check List

Sorry that I did not add a test case so far. Do you think this is necessary? What kind of test would be ideal?

## Review

  - Read and verify the code changes
  - Test the functionality by running the UI locally with all popular browsers available in your platform
  - Check that the implementation matches the design, when such one is defined in a Jira issue
  - Merge the pull request
