### PR TITLE
Replace moment by moment-timezone

### DIFF
--- a/app/component/AirportCheckInLeg.js
+++ b/app/component/AirportCheckInLeg.js
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import { FormattedMessage, intlShape } from 'react-intl';
-import moment from 'moment';
+import moment from 'moment-timezone';
 import { Link } from 'found';
 import ItineraryCircleLine from './ItineraryCircleLine';
 import Icon from './Icon';

--- a/app/component/AirportCollectLuggageLeg.js
+++ b/app/component/AirportCollectLuggageLeg.js
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import { FormattedMessage, intlShape } from 'react-intl';
-import moment from 'moment';
+import moment from 'moment-timezone';
 import { Link } from 'found';
 import ItineraryCircleLine from './ItineraryCircleLine';
 import Icon from './Icon';

--- a/app/component/BicycleLeg.js
+++ b/app/component/BicycleLeg.js
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import moment from 'moment';
+import moment from 'moment-timezone';
 import { FormattedMessage, intlShape } from 'react-intl';
 import cx from 'classnames';
 import Link from 'found/Link';

--- a/app/component/BikeParkLeg.js
+++ b/app/component/BikeParkLeg.js
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types';
 import cx from 'classnames';
 import React from 'react';
-import moment from 'moment';
+import moment from 'moment-timezone';
 import { Link } from 'found';
 import { FormattedMessage, intlShape } from 'react-intl';
 import { displayDistance } from '../util/geo-utils';

--- a/app/component/CallAgencyLeg.js
+++ b/app/component/CallAgencyLeg.js
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import Link from 'found/Link';
-import moment from 'moment';
+import moment from 'moment-timezone';
 import { FormattedMessage } from 'react-intl';
 
 import RouteNumber from './RouteNumber';

--- a/app/component/CarLeg.js
+++ b/app/component/CarLeg.js
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import moment from 'moment';
+import moment from 'moment-timezone';
 import { FormattedMessage, intlShape } from 'react-intl';
 
 import Icon from './Icon';

--- a/app/component/CarParkLeg.js
+++ b/app/component/CarParkLeg.js
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import moment from 'moment';
+import moment from 'moment-timezone';
 import { FormattedMessage, intlShape } from 'react-intl';
 import cx from 'classnames';
 

--- a/app/component/CarpoolLeg.js
+++ b/app/component/CarpoolLeg.js
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types';
 import { FormattedMessage, intlShape } from 'react-intl';
-import moment from 'moment';
+import moment from 'moment-timezone';
 import React from 'react';
 import cx from 'classnames';
 import { displayDistance } from '../util/geo-utils';

--- a/app/component/CarpoolOffer.js
+++ b/app/component/CarpoolOffer.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { intlShape, FormattedMessage, FormattedHTMLMessage } from 'react-intl';
-import Moment from 'moment';
+import Moment from 'moment-timezone';
 import { routerShape } from 'found';
 import Icon from './Icon';
 import Checkbox from './Checkbox';

--- a/app/component/DelayedTime.js
+++ b/app/component/DelayedTime.js
@@ -1,5 +1,5 @@
 import cx from 'classnames';
-import moment from 'moment';
+import moment from 'moment-timezone';
 import React from 'react';
 import PropTypes from 'prop-types';
 import { legHasCancelation } from '../util/alertUtils';

--- a/app/component/DepartureRow.js
+++ b/app/component/DepartureRow.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import cx from 'classnames';
-import moment from 'moment';
+import moment from 'moment-timezone';
 import { intlShape } from 'react-intl';
 import { v4 as uuid } from 'uuid';
 import { Link } from 'found';

--- a/app/component/EndLeg.js
+++ b/app/component/EndLeg.js
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import moment from 'moment';
+import moment from 'moment-timezone';
 import cx from 'classnames';
 import { matchShape } from 'found';
 

--- a/app/component/IndexPage.js
+++ b/app/component/IndexPage.js
@@ -8,7 +8,7 @@ import isEqual from 'lodash/isEqual';
 import DTAutoSuggest from '@digitransit-component/digitransit-component-autosuggest';
 import DTAutosuggestPanel from '@digitransit-component/digitransit-component-autosuggest-panel';
 import { getModesWithAlerts } from '@digitransit-search-util/digitransit-search-util-query-utils';
-import moment from 'moment';
+import moment from 'moment-timezone';
 import storeOrigin from '../action/originActions';
 import storeDestination from '../action/destinationActions';
 import withSearchContext from './WithSearchContext';

--- a/app/component/IntermediateLeg.js
+++ b/app/component/IntermediateLeg.js
@@ -1,5 +1,5 @@
 import cx from 'classnames';
-import moment from 'moment';
+import moment from 'moment-timezone';
 import PropTypes from 'prop-types';
 import React from 'react';
 import Link from 'found/Link';

--- a/app/component/LocalTime.js
+++ b/app/component/LocalTime.js
@@ -1,4 +1,4 @@
-import moment from 'moment';
+import moment from 'moment-timezone';
 import PropTypes from 'prop-types';
 
 const LocalTime = ({ forceUtc, time }) => {

--- a/app/component/RelativeDuration.js
+++ b/app/component/RelativeDuration.js
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import moment from 'moment';
+import moment from 'moment-timezone';
 import { FormattedMessage, intlShape } from 'react-intl';
 
 function RelativeDuration(props) {

--- a/app/component/RouteAlertsRow.js
+++ b/app/component/RouteAlertsRow.js
@@ -1,7 +1,7 @@
 /* eslint-disable jsx-a11y/no-noninteractive-tabindex */
 import cx from 'classnames';
 import capitalize from 'lodash/capitalize';
-import moment from 'moment';
+import moment from 'moment-timezone';
 import PropTypes from 'prop-types';
 import React from 'react';
 import { intlShape } from 'react-intl';

--- a/app/component/RoutePageControlPanel.js
+++ b/app/component/RoutePageControlPanel.js
@@ -1,5 +1,5 @@
 /* eslint-disable import/no-unresolved */
-import moment from 'moment';
+import moment from 'moment-timezone';
 import PropTypes from 'prop-types';
 import React from 'react';
 import { FormattedMessage, intlShape } from 'react-intl';

--- a/app/component/RouteScheduleContainer.js
+++ b/app/component/RouteScheduleContainer.js
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types';
 import React, { PureComponent } from 'react';
 import { createFragmentContainer, graphql } from 'react-relay';
 import { matchShape, routerShape, RedirectException } from 'found';
-import moment from 'moment';
+import moment from 'moment-timezone';
 import { intlShape, FormattedMessage } from 'react-intl';
 import sortBy from 'lodash/sortBy';
 import cx from 'classnames';

--- a/app/component/RouteStopListContainer.js
+++ b/app/component/RouteStopListContainer.js
@@ -7,7 +7,7 @@ import groupBy from 'lodash/groupBy';
 import values from 'lodash/values';
 import cx from 'classnames';
 import { FormattedMessage } from 'react-intl';
-import moment from 'moment';
+import moment from 'moment-timezone';
 
 import RouteStop from './RouteStop';
 import withBreakpoint from '../util/withBreakpoint';

--- a/app/component/StopPageTabs.js
+++ b/app/component/StopPageTabs.js
@@ -1,5 +1,5 @@
 import cx from 'classnames';
-import moment from 'moment';
+import moment from 'moment-timezone';
 import PropTypes from 'prop-types';
 import React, { useState, useRef } from 'react';
 import { FormattedMessage, intlShape } from 'react-intl';

--- a/app/component/StopTimetablePage.js
+++ b/app/component/StopTimetablePage.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { createRefetchContainer, graphql } from 'react-relay';
-import moment from 'moment';
+import moment from 'moment-timezone';
 
 import { matchShape, routerShape } from 'found';
 import { prepareServiceDay } from '../util/dateParamUtils';

--- a/app/component/SummaryPage.js
+++ b/app/component/SummaryPage.js
@@ -1,7 +1,7 @@
 /* eslint-disable react/no-array-index-key */
 /* eslint-disable no-nested-ternary */
 import PropTypes from 'prop-types';
-import moment from 'moment';
+import moment from 'moment-timezone';
 import React from 'react';
 import {
   createRefetchContainer,

--- a/app/component/SummaryPlanContainer.js
+++ b/app/component/SummaryPlanContainer.js
@@ -1,6 +1,6 @@
 /* eslint-disable no-nested-ternary */
 import connectToStores from 'fluxible-addons-react/connectToStores';
-import moment from 'moment';
+import moment from 'moment-timezone';
 import PropTypes from 'prop-types';
 import React from 'react';
 import {

--- a/app/component/SummaryRow.js
+++ b/app/component/SummaryRow.js
@@ -1,5 +1,5 @@
 import cx from 'classnames';
-import moment from 'moment';
+import moment from 'moment-timezone';
 import PropTypes from 'prop-types';
 import React from 'react';
 import { FormattedMessage, intlShape } from 'react-intl';

--- a/app/component/TerminalTimetablePage.js
+++ b/app/component/TerminalTimetablePage.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { createRefetchContainer, graphql } from 'react-relay';
-import moment from 'moment';
+import moment from 'moment-timezone';
 
 import { matchShape, routerShape } from 'found';
 import { prepareServiceDay } from '../util/dateParamUtils';

--- a/app/component/TicketInformation.js
+++ b/app/component/TicketInformation.js
@@ -4,7 +4,7 @@ import React from 'react';
 import { FormattedMessage, FormattedHTMLMessage, intlShape } from 'react-intl';
 
 import { v4 as uuid } from 'uuid';
-import Moment from 'moment';
+import Moment from 'moment-timezone';
 import ExternalLink from './ExternalLink';
 import { renderZoneTicket } from './ZoneTicket';
 import { getAlternativeFares } from '../util/fareUtils';

--- a/app/component/TimeFrame.js
+++ b/app/component/TimeFrame.js
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import moment from 'moment';
+import moment from 'moment-timezone';
 
 import { TIME_PATTERN, DATE_PATTERN } from '../util/timeUtils';
 

--- a/app/component/Timetable.js
+++ b/app/component/Timetable.js
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import moment from 'moment';
+import moment from 'moment-timezone';
 import uniqBy from 'lodash/uniqBy';
 import sortBy from 'lodash/sortBy';
 import groupBy from 'lodash/groupBy';

--- a/app/component/TimetableRow.js
+++ b/app/component/TimetableRow.js
@@ -2,7 +2,7 @@
 import cx from 'classnames';
 import PropTypes from 'prop-types';
 import React from 'react';
-import moment from 'moment';
+import moment from 'moment-timezone';
 import { intlShape } from 'react-intl';
 
 const TimetableRow = ({ title, stoptimes, showRoutes, timerows }, { intl }) => (

--- a/app/component/TransitLeg.js
+++ b/app/component/TransitLeg.js
@@ -1,5 +1,5 @@
 import cx from 'classnames';
-import moment from 'moment';
+import moment from 'moment-timezone';
 import PropTypes from 'prop-types';
 import React from 'react';
 import { FormattedMessage, intlShape } from 'react-intl';

--- a/app/component/TripStopListContainer.js
+++ b/app/component/TripStopListContainer.js
@@ -6,7 +6,7 @@ import isEmpty from 'lodash/isEmpty';
 import connectToStores from 'fluxible-addons-react/connectToStores';
 import groupBy from 'lodash/groupBy';
 import values from 'lodash/values';
-import moment from 'moment';
+import moment from 'moment-timezone';
 import { getRouteMode } from '../util/modeUtils';
 import TripRouteStop from './TripRouteStop';
 import withBreakpoint from '../util/withBreakpoint';

--- a/app/component/ViaLeg.js
+++ b/app/component/ViaLeg.js
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import moment from 'moment';
+import moment from 'moment-timezone';
 import { FormattedMessage, intlShape } from 'react-intl';
 
 import Icon from './Icon';

--- a/app/component/WalkLeg.js
+++ b/app/component/WalkLeg.js
@@ -1,4 +1,4 @@
-import moment from 'moment';
+import moment from 'moment-timezone';
 import cx from 'classnames';
 import PropTypes from 'prop-types';
 import React from 'react';

--- a/app/component/WeatherDetailsPopup.js
+++ b/app/component/WeatherDetailsPopup.js
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import moment from 'moment';
+import moment from 'moment-timezone';
 import Modal from '@hsl-fi/modal';
 import { FormattedMessage, intlShape } from 'react-intl';
 

--- a/app/component/map/StopPageMap.js
+++ b/app/component/map/StopPageMap.js
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types';
 import React, { useEffect, useContext, useState } from 'react';
 import { matchShape, routerShape } from 'found';
-import moment from 'moment';
+import moment from 'moment-timezone';
 import { connectToStores } from 'fluxible-addons-react';
 import distance from '@digitransit-search-util/digitransit-search-util-distance';
 import { graphql, fetchQuery } from 'react-relay';

--- a/app/component/map/StopsNearYouMap.js
+++ b/app/component/map/StopsNearYouMap.js
@@ -2,7 +2,7 @@ import React, { useEffect, useState, useRef } from 'react';
 import PropTypes from 'prop-types';
 import { matchShape } from 'found';
 import { graphql, fetchQuery } from 'react-relay';
-import moment from 'moment';
+import moment from 'moment-timezone';
 import uniqBy from 'lodash/uniqBy';
 import compact from 'lodash/compact';
 import indexOf from 'lodash/indexOf';

--- a/app/component/map/VehicleMarkerContainer.js
+++ b/app/component/map/VehicleMarkerContainer.js
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import connectToStores from 'fluxible-addons-react/connectToStores';
-import moment from 'moment';
+import moment from 'moment-timezone';
 import { ExtendedRouteTypes } from '../../constants';
 import VehicleIcon from '../VehicleIcon';
 import IconMarker from './IconMarker';

--- a/app/component/map/popups/OSMOpeningHours.js
+++ b/app/component/map/popups/OSMOpeningHours.js
@@ -2,7 +2,7 @@ import SimpleOpeningHours from 'simple-opening-hours';
 import React from 'react';
 import PropTypes from 'prop-types';
 import { FormattedMessage, intlShape } from 'react-intl';
-import moment from 'moment';
+import moment from 'moment-timezone';
 import Icon from '../../Icon';
 
 export default class OSMOpeningHours extends React.Component {

--- a/app/component/map/route/TripMarkerPopup.js
+++ b/app/component/map/route/TripMarkerPopup.js
@@ -4,7 +4,7 @@ import { createFragmentContainer, graphql } from 'react-relay';
 
 import Link from 'found/Link';
 import { FormattedMessage } from 'react-intl';
-import moment from 'moment';
+import moment from 'moment-timezone';
 import { PREFIX_ROUTES, PREFIX_STOPS } from '../../../util/path';
 
 import RouteHeader from '../../RouteHeader';

--- a/app/component/map/sidebar/RoadworksContent.js
+++ b/app/component/map/sidebar/RoadworksContent.js
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import moment from 'moment';
+import moment from 'moment-timezone';
 import { intlShape } from 'react-intl';
 import withBreakpoint from '../../../util/withBreakpoint';
 import SidebarContainer from './SidebarContainer';

--- a/app/component/map/sidebar/WeatherStationContent.js
+++ b/app/component/map/sidebar/WeatherStationContent.js
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import { FormattedMessage, intlShape } from 'react-intl';
-import moment from 'moment';
+import moment from 'moment-timezone';
 import { isNumber } from 'lodash';
 import SidebarContainer from './SidebarContainer';
 

--- a/app/configurations/config.stadtnavi.js
+++ b/app/configurations/config.stadtnavi.js
@@ -5,7 +5,7 @@ import { MapMode } from '../constants';
 const CONFIG = 'stadtnavi';
 const APP_TITLE = 'stadtnavi Herrenberg';
 const APP_DESCRIPTION = 'Gemeinsam Mobilität neu denken - die intermodale Verbindungssuche mit offenen, lokalen Daten';
-const API_URL = process.env.API_URL || 'https://api.dev.stadtnavi.eu';
+const API_URL = process.env.API_URL || 'https://api.stadtnavi.de';
 const MAP_URL = process.env.MAP_URL || 'https://tiles.stadtnavi.eu/streets/{z}/{x}/{y}{r}.png';
 const BIKE_MAP_URL = process.env.BIKE_MAP_URL ||'https://tiles.stadtnavi.eu/bicycle/{z}/{x}/{y}{r}.png';
 

--- a/app/store/OldSearchesStore.js
+++ b/app/store/OldSearchesStore.js
@@ -4,7 +4,7 @@ import find from 'lodash/find';
 import get from 'lodash/get';
 import isEqual from 'lodash/isEqual';
 import orderBy from 'lodash/orderBy';
-import moment from 'moment';
+import moment from 'moment-timezone';
 
 import { getNameLabel } from '@digitransit-search-util/digitransit-search-util-uniq-by-label';
 import { getOldSearchesStorage, setOldSearchesStorage } from './localStorage';

--- a/app/store/TimeStore.js
+++ b/app/store/TimeStore.js
@@ -1,5 +1,5 @@
 import Store from 'fluxible/addons/BaseStore';
-import moment from 'moment';
+import moment from 'moment-timezone';
 
 class TimeStore extends Store {
   static storeName = 'TimeStore';

--- a/app/util/apiUtils.js
+++ b/app/util/apiUtils.js
@@ -1,4 +1,4 @@
-import moment from 'moment';
+import moment from 'moment-timezone';
 import xmlParser from 'fast-xml-parser';
 import isEmpty from 'lodash/isEmpty';
 import { retryFetch } from './fetchUtils';

--- a/app/util/dateParamUtils.js
+++ b/app/util/dateParamUtils.js
@@ -1,4 +1,4 @@
-import moment from 'moment';
+import moment from 'moment-timezone';
 
 import { DATE_FORMAT } from '../constants';
 

--- a/app/util/mqttClient.js
+++ b/app/util/mqttClient.js
@@ -1,5 +1,5 @@
 import ceil from 'lodash/ceil';
-import moment from 'moment';
+import moment from 'moment-timezone';
 import { parseFeedMQTT } from './gtfsRtParser';
 import { convertTo24HourFormat } from './timeUtils';
 

--- a/app/util/patternUtils.js
+++ b/app/util/patternUtils.js
@@ -1,4 +1,4 @@
-import moment from 'moment';
+import moment from 'moment-timezone';
 /**
  Helper for determining is current date in active dates.
  Return false if pattern doesn't have active dates information available

--- a/app/util/planParamUtil.js
+++ b/app/util/planParamUtil.js
@@ -1,5 +1,5 @@
 import omitBy from 'lodash/omitBy';
-import moment from 'moment';
+import moment from 'moment-timezone';
 import Cookies from 'universal-cookie';
 import booleanPointInPolygon from '@turf/boolean-point-in-polygon';
 import point from 'turf-point';

--- a/app/util/routePatternSelectUtil.js
+++ b/app/util/routePatternSelectUtil.js
@@ -5,7 +5,7 @@
 /* eslint-disable prefer-destructuring */
 
 import cloneDeep from 'lodash/cloneDeep';
-import moment from 'moment';
+import moment from 'moment-timezone';
 
 export const DATE_FORMAT = 'YYYYMMDD';
 export const DATE_FORMAT2 = 'D.M.';

--- a/app/util/routeScheduleParamUtils.js
+++ b/app/util/routeScheduleParamUtils.js
@@ -1,4 +1,4 @@
-import moment from 'moment';
+import moment from 'moment-timezone';
 import { DATE_FORMAT } from '../constants';
 
 const populateData = (params, match, noOfWeeks) => {

--- a/app/util/timeUtils.js
+++ b/app/util/timeUtils.js
@@ -1,4 +1,4 @@
-import moment from 'moment';
+import moment from 'moment-timezone';
 
 export const TIME_PATTERN = 'HH:mm';
 export const DATE_PATTERN = 'dd D.M.';

--- a/config/rollup.config.js
+++ b/config/rollup.config.js
@@ -18,7 +18,7 @@ const globals = {
   classnames: 'cx',
   'prop-types': 'PropTypes',
   i18next: 'i18next',
-  'moment-timezone': 'moment',
+  'moment-timezone': 'moment-timezone',
   'react-autosuggest': 'Autosuggest',
   'react-sortablejs': 'reactSortablejs',
   'react-modal': 'ReactModal',
@@ -48,7 +48,7 @@ const globals = {
   'lodash/get': 'get',
   'lodash/uniq': 'uniq',
   'lodash/compact': 'compact',
-  moment: 'moment',
+  moment: 'moment-timezone',
   'react-relay': 'reactRelay',
 };
 

--- a/digitransit-search-util/packages/digitransit-search-util-query-utils/index.js
+++ b/digitransit-search-util/packages/digitransit-search-util-query-utils/index.js
@@ -3,7 +3,7 @@ import take from 'lodash/take';
 import flatten from 'lodash/flatten';
 import uniq from 'lodash/uniq';
 import compact from 'lodash/compact';
-import moment from 'moment';
+import moment from 'moment-timezone';
 import { fetchQuery, graphql } from 'react-relay';
 import routeNameCompare from '@digitransit-search-util/digitransit-search-util-route-name-compare';
 import {

--- a/digitransit-util/packages/digitransit-util-enrich-patterns/index.js
+++ b/digitransit-util/packages/digitransit-util-enrich-patterns/index.js
@@ -5,7 +5,7 @@
 /* eslint-disable prefer-destructuring */
 import dayRangeAllowedDiff from '@digitransit-util/digitransit-util-day-range-allowed-diff';
 import cloneDeep from 'lodash/cloneDeep';
-import moment from 'moment';
+import moment from 'moment-timezone';
 
 const DATE_FORMAT = 'YYYYMMDD';
 

--- a/digitransit-util/packages/digitransit-util-enrich-patterns/test.js
+++ b/digitransit-util/packages/digitransit-util-enrich-patterns/test.js
@@ -1,7 +1,7 @@
 /* eslint-disable import/no-extraneous-dependencies */
 import { expect } from 'chai';
 import { describe, it } from 'mocha';
-import moment from 'moment';
+import moment from 'moment-timezone';
 import enrichPatterns from '.';
 
 describe('Testing @digitransit-util/digitransit-util-enrich-patterns module', () => {

--- a/digitransit-util/packages/digitransit-util-route-pattern-option-text/index.js
+++ b/digitransit-util/packages/digitransit-util-route-pattern-option-text/index.js
@@ -2,7 +2,7 @@
 /* eslint-disable no-nested-ternary */
 /* eslint no-bitwise: ["error", { "allow": [">>"] }] */
 
-import moment from 'moment';
+import moment from 'moment-timezone';
 import i18next from 'i18next';
 import translations from './helpers/translations';
 

--- a/digitransit-util/packages/digitransit-util-route-pattern-option-text/test.js
+++ b/digitransit-util/packages/digitransit-util-route-pattern-option-text/test.js
@@ -2,7 +2,7 @@
 /* eslint-disable func-names */
 import { expect } from 'chai';
 import { describe, it } from 'mocha';
-import moment from 'moment';
+import moment from 'moment-timezone';
 import cloneDeep from 'lodash/cloneDeep';
 import routePatternOptionText from '.';
 

--- a/server/passport-openid-connect/Strategy.js
+++ b/server/passport-openid-connect/Strategy.js
@@ -3,7 +3,7 @@
 'use strict';
 
 const { Issuer, Strategy, custom } = require('openid-client');
-const moment = require('moment');
+const moment = require('moment-timezone');
 const util = require('util');
 const process = require('process');
 const User = require('./User').User;

--- a/server/passport-openid-connect/openidConnect.js
+++ b/server/passport-openid-connect/openidConnect.js
@@ -3,7 +3,7 @@ const passport = require('passport');
 const session = require('express-session');
 const redis = require('redis');
 const axios = require('axios');
-const moment = require('moment');
+const moment = require('moment-timezone');
 const RedisStore = require('connect-redis')(session);
 const LoginStrategy = require('./Strategy').Strategy;
 

--- a/test/unit/OldSearchesStore.test.js
+++ b/test/unit/OldSearchesStore.test.js
@@ -2,7 +2,7 @@
 import { expect } from 'chai';
 import { afterEach, describe, it } from 'mocha';
 import MockDate from 'mockdate';
-import moment from 'moment';
+import moment from 'moment-timezone';
 
 import OldSearchesStore, {
   STORE_VERSION,

--- a/test/unit/component/LangSelect.test.js
+++ b/test/unit/component/LangSelect.test.js
@@ -1,7 +1,7 @@
 import { expect } from 'chai';
 import { describe, it } from 'mocha';
 import React from 'react';
-import moment from 'moment';
+import moment from 'moment-timezone';
 
 import { mockContext } from '../helpers/mock-context';
 import { shallowWithIntl } from '../helpers/mock-intl-enzyme';

--- a/test/unit/component/RoutePageControlPanel.test.js
+++ b/test/unit/component/RoutePageControlPanel.test.js
@@ -3,7 +3,7 @@ import { describe, it } from 'mocha';
 import React from 'react';
 import sinon from 'sinon';
 
-import moment from 'moment';
+import moment from 'moment-timezone';
 import { mockContext } from '../helpers/mock-context';
 import { mockMatch, mockRouter } from '../helpers/mock-router';
 import { shallowWithIntl } from '../helpers/mock-intl-enzyme';

--- a/test/unit/component/RoutePatternSelect.test.js
+++ b/test/unit/component/RoutePatternSelect.test.js
@@ -4,7 +4,7 @@ import { describe, it } from 'mocha';
 import React from 'react';
 import sinon from 'sinon';
 
-import moment from 'moment'; // DT-3182
+import moment from 'moment-timezone'; // DT-3182
 import { shallowWithIntl } from '../helpers/mock-intl-enzyme';
 import { mockContext } from '../helpers/mock-context';
 import { Component as RoutePatternSelect } from '../../../app/component/RoutePatternSelect';

--- a/test/unit/component/RouteStopListContainer.test.js
+++ b/test/unit/component/RouteStopListContainer.test.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import moment from 'moment';
+import moment from 'moment-timezone';
 
 import { shallowWithIntl } from '../helpers/mock-intl-enzyme';
 import { Component as RouteStopListContainer } from '../../../app/component/RouteStopListContainer';

--- a/test/unit/component/TripStopListContainer.test.js
+++ b/test/unit/component/TripStopListContainer.test.js
@@ -1,4 +1,4 @@
-import moment from 'moment';
+import moment from 'moment-timezone';
 import React from 'react';
 
 import TripRouteStop from '../../../app/component/TripRouteStop';

--- a/test/unit/helpers/mock-context.js
+++ b/test/unit/helpers/mock-context.js
@@ -1,4 +1,4 @@
-import moment from 'moment';
+import moment from 'moment-timezone';
 import PropTypes from 'prop-types';
 import { matchShape, routerShape } from 'found';
 

--- a/test/unit/store/RealTimeInformationStore.test.js
+++ b/test/unit/store/RealTimeInformationStore.test.js
@@ -1,6 +1,6 @@
 import { expect } from 'chai';
 import { beforeEach, describe, it } from 'mocha';
-import moment from 'moment';
+import moment from 'moment-timezone';
 import sinon from 'sinon';
 
 import RealTimeInformationStore from '../../../app/store/RealTimeInformationStore';

--- a/test/unit/test-data/dt2887.js
+++ b/test/unit/test-data/dt2887.js
@@ -1,4 +1,4 @@
-import moment from 'moment';
+import moment from 'moment-timezone';
 import { PREFIX_STOPS } from '../../../app/util/path';
 
 export default {

--- a/test/unit/test-data/dt2887b.js
+++ b/test/unit/test-data/dt2887b.js
@@ -1,4 +1,4 @@
-import moment from 'moment';
+import moment from 'moment-timezone';
 import { PREFIX_STOPS } from '../../../app/util/path';
 
 export default {

--- a/test/unit/util/timeUtils.test.js
+++ b/test/unit/util/timeUtils.test.js
@@ -1,6 +1,6 @@
 import { expect } from 'chai';
 import { describe, it } from 'mocha';
-import moment from 'moment';
+import moment from 'moment-timezone';
 import {
   validateServiceTimeRange,
   RANGE_PAST,


### PR DESCRIPTION
Currently, we encounter random switches to Finish date time display, i.e. workdays are formatted in finish, wrong timezone is used. Switching to moment-timezone fixes this.
