### PR TITLE
Fix wrong walk leg start time

### DIFF
--- a/app/component/WalkLeg.js
+++ b/app/component/WalkLeg.js
@@ -24,16 +24,7 @@ import DelayedTime from './DelayedTime';
 import WalkSteps from './WalkSteps';
 
 function WalkLeg(
-  {
-    children,
-    focusAction,
-    focusToLeg,
-    focusToStep,
-    index,
-    leg,
-    previousLeg,
-    startTime,
-  },
+  { children, focusAction, focusToLeg, focusToStep, index, leg, previousLeg },
   { config, intl },
 ) {
   const distance = displayDistance(
@@ -112,7 +103,7 @@ function WalkLeg(
             <DelayedTime
               leg={previousLeg}
               delay={previousLeg && previousLeg.arrivalDelay}
-              startTime={startTime}
+              startTime={leg.mode === 'WALK' ? leg.startTime : leg.endTime}
             />
           </div>
         </div>
@@ -400,9 +391,6 @@ WalkLeg.propTypes = {
   previousLeg: walkLegShape,
   focusToLeg: PropTypes.func.isRequired,
   focusToStep: PropTypes.func.isRequired,
-  // This is not necessarily the `leg`'s start time!
-  // Usually, it seems to be the previous leg's end time.
-  startTime: PropTypes.number.isRequired,
 };
 
 WalkLeg.defaultProps = {


### PR DESCRIPTION
This PR fixes a wrongly displayed start time in case the last leg of a transit itinerary is not an explicit WALK leg, like in [this example](https://mobi.vpe.de/reiseplan/Pforzheim%20Hauptbahnhof%2C%20Pforzheim%3A%3A48.8939815%2C8.7032583/Ellmendingen%20Pforzheimer%20Stra%C3%9Fe%2C%20Keltern%3A%3A48.9012094%2C8.5765561/?time=1732276130), where the arrival time is shown as the current time:

![grafik](https://github.com/user-attachments/assets/3123ec76-b9c2-428c-939a-71d16add5962)

In case the last leg is not a WALK leg, but the previous transit leg, it's endtime needs to be displayed, otherwise the start time.