### PR TITLE
fix(map-layer): rename geojson category to bicycle

### DIFF
--- a/app/component/MapLayersDialogContent.js
+++ b/app/component/MapLayersDialogContent.js
@@ -337,7 +337,7 @@ class MapLayersDialogContent extends React.Component {
               ]
                 .concat(
                   this.layerOptionsByCategory(
-                    'bicycle_car',
+                    'bicycle',
                     config.geoJson?.layers,
                     geoJson,
                     this.props.lang,

--- a/app/configurations/config.herrenberg.js
+++ b/app/configurations/config.herrenberg.js
@@ -360,7 +360,7 @@ export default configMerger(parentConfig, {
             de: 'Service Stationen und Läden',
           },
           url: 'https://data.mfdz.de/hbg/dt-layers/bicycleinfrastructure.geojson',
-          category: 'bicycle_car',
+          category: 'bicycle',
           icon: 'icon-icon_bike_repair',
         },
         // Bicycle network layer
@@ -370,7 +370,7 @@ export default configMerger(parentConfig, {
             en: "Bicycle network",
             de: 'Radnetz',
           },
-          category: 'bicycle_car',
+          category: 'bicycle',
           url: 'https://api.mobidata-bw.de/geoserver/MobiData-BW/wms',
           icon: 'icon-icon_radnetz',
           isOffByDefault: true,


### PR DESCRIPTION
For comment: https://github.com/stadtnavi/digitransit-ui/pull/858/files#r1890576704

Category `bicycle` still needed for other cities' configurations.
