### PR TITLE
fix(map-layer-dialog): map type icons are cut at the bottom

### DIFF
--- a/app/component/settings-panel.scss
+++ b/app/component/settings-panel.scss
@@ -1,7 +1,7 @@
 .offcanvas-layers {
   width: 400px;
   height: initial;
-  max-height: calc(100% - 70px);
+  max-height: calc(100% - 150px);
   display: flex;
   flex-direction: column;
   background-color: white;


### PR DESCRIPTION
closes #841 

<img width="400" alt="image" src="https://github.com/user-attachments/assets/30e0d520-6ce8-4827-9184-d228edf6b9fa" />
