### PR TITLE
Fix: add email icon for sight details

### DIFF
--- a/static/svg-icons/stadtnavi/icon-icon_email.svg
+++ b/static/svg-icons/stadtnavi/icon-icon_email.svg
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<svg width="100%" height="100%" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M4 7.00005L10.2 11.65C11.2667 12.45 12.7333 12.45 13.8 11.65L20 7" stroke="#000000" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<rect x="3" y="5" width="18" height="14" rx="2" stroke="#000000" stroke-width="2" stroke-linecap="round"/>
+</svg>


### PR DESCRIPTION
This PR adds an email icon which is displayed for sights:

<img width="238" alt="image" src="https://github.com/user-attachments/assets/d1773305-0eaa-4cb4-8f56-c740d4111042" />

@GustavoTCh  