### PR TITLE
Fix: rental layers activation

### DIFF
--- a/app/store/MapLayerStore.js
+++ b/app/store/MapLayerStore.js
@@ -117,6 +117,9 @@ class MapLayerStore extends Store {
 
   updateMapLayers = mapLayers => {
     this.mapLayers = defaultsDeep(cloneDeep(mapLayers), this.mapLayers);
+    this.mapLayers.citybike = Object.values(this.mapLayers.rental || {}).some(
+      v => v === true,
+    );
     setMapLayerSettings({ ...this.mapLayers });
     this.emitChange();
   };


### PR DESCRIPTION
This PR sets `maplayers.citybike` (aka rental) depending on activation of formFactor specific sharing layers. 

Fixes #951