### PR TITLE
Fix: direction abbrevation

### DIFF
--- a/app/translations.js
+++ b/app/translations.js
@@ -580,7 +580,7 @@ const translations = {
     'choose-stop': 'Option auswählen',
     'choose-stop-or-vehicle': 'Fahrzeug oder Haltestelle auswählen',
     'choose-vehicle': 'Fahrzeug auswählen',
-    'direction': 'Ri. ',
+    'direction': 'Richtung ',
     'position-estimated': 'Position geschätzt. Keine aktuellen Positionsinformationen verfügbar.',
     citybike: 'Sharing-Angebote',
     'citybike-buy-season': 'Ticket für Tag, Monat oder Jahr kaufen',


### PR DESCRIPTION
This PR spells out "Ri." to "Richtung". Fixes #959 