### PR TITLE
fix: suppress carPlaces text if unset

### DIFF
--- a/app/component/map/sidebar/DynamicParkingLotsContent.js
+++ b/app/component/map/sidebar/DynamicParkingLotsContent.js
@@ -53,8 +53,7 @@ class DynamicParkingLotsContent extends React.Component {
     const { intl } = this.context;
     const free = this.props.vehicleParking.availability?.carSpaces;
     const total = this.props.vehicleParking.capacity?.carSpaces;
-
-    if (Number(free) || Number(free) === 0) {
+    if (free !== null) {
       return intl.formatMessage(
         {
           id: 'parking-spaces-available',
@@ -64,7 +63,7 @@ class DynamicParkingLotsContent extends React.Component {
       );
     }
 
-    if (Number(total)) {
+    if (total !== null) {
       return intl.formatMessage(
         {
           id: 'parking-spaces-in-total',


### PR DESCRIPTION
This PR suppresses the rendering of the number of car parking places, in case this is not set:

<img width="338" height="108" alt="image" src="https://github.com/user-attachments/assets/26404d44-ec5e-463a-8188-b32111234a47" />
 becomes

<img width="309" height="75" alt="image" src="https://github.com/user-attachments/assets/53a3870f-18e5-4863-90b6-2ecc3d0c8a2b" />
