### PR TITLE
Feat/vvs rider

### DIFF
--- a/app/configurations/config.herrenberg.js
+++ b/app/configurations/config.herrenberg.js
@@ -618,5 +618,7 @@ export default configMerger(parentConfig, {
 
     showCO2InItinerarySummary: true,
 
-    EMISSIONS_INFO: 'https://www.herrenberg.de/Mobilit%C3%A4t/CO2'
+    EMISSIONS_INFO: 'https://www.herrenberg.de/Mobilit%C3%A4t/CO2',
+
+    includeOnDemandSuggestionsWithDefault: true,
 });

--- a/app/util/planParamUtil.js
+++ b/app/util/planParamUtil.js
@@ -374,15 +374,15 @@ export const preparePlanParams = (config, useDefaultModes) => (
     ),
     // These modes are used by the "default" routing query.
     modes: [
-      // In stadtnavi, we want flex routing to be displayed as proper mode.
-      /*
-      ...(formattedModes.some(({ mode }) => mode === 'BUS')
+      // As ondemand is more and more common, we include flex routing in standard transit mode.
+      ...(config.includeOnDemandSuggestionsWithDefault === true &&
+      formattedModes.some(({ mode }) => mode === 'BUS')
         ? [
             { mode: 'FLEX', qualifier: 'DIRECT' },
             { mode: 'FLEX', qualifier: 'ACCESS' },
             { mode: 'FLEX', qualifier: 'EGRESS' },
           ]
-        : []), */
+        : []),
       ...formattedModes,
     ],
     ticketTypes,
@@ -418,9 +418,10 @@ export const preparePlanParams = (config, useDefaultModes) => (
       settings,
       defaultSettings,
     ),
+    // Optionally show OnDemandResults as extra tab
+    shouldMakeOnDemandTaxiQuery:
+      config.includeOnDemandSuggestionsAsExtra === true,
     // TODO shouldMakeXYZQuery and showXYZItineraries have same intend, harmonize
-    // In bbnavi, we include Flex routing in the "default" public routing mode.
-    shouldMakeOnDemandTaxiQuery: false,
     showBikeAndPublicItineraries:
       !wheelchair &&
       config.showBikeAndPublicItineraries &&

--- a/static/svg-icons/stadtnavi/icon-icon_call.svg
+++ b/static/svg-icons/stadtnavi/icon-icon_call.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 24 24" version="1.1" fill="#747474">
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 24 24" version="1.1" fill="#ffffff">
   <path d="M0 0h24v24H0z" fill="none"/>
   <path d="M20.01 15.38c-1.23 0-2.42-.2-3.53-.56-.35-.12-.74-.03-1.01.24l-1.57 1.97c-2.83-1.35-5.48-3.9-6.89-6.83l1.95-1.66c.27-.28.35-.67.24-1.02-.37-1.11-.56-2.3-.56-3.53 0-.54-.45-.99-.99-.99H4.19C3.65 3 3 3.24 3 3.99 3 13.28 10.73 21 20.01 21c.71 0 .99-.63.99-1.18v-3.45c0-.54-.45-.99-.99-.99z"/>
 </svg>


### PR DESCRIPTION
This PR actives FLEX modes for herrenberg, to provide vvs-rider connections.

<img width="466" height="688" alt="grafik" src="https://github.com/user-attachments/assets/28948c6a-91b8-4e51-a554-a06ff2c88c24" />
